### PR TITLE
MTDSA-10078

### DIFF
--- a/app/v2/connectors/DeletePropertyAnnualSubmissionConnector.scala
+++ b/app/v2/connectors/DeletePropertyAnnualSubmissionConnector.scala
@@ -26,13 +26,15 @@ import v2.models.request.deletePropertyAnnualSubmission.DeletePropertyAnnualSubm
 import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton
-class DeleteForeignPropertyAnnualSubmissionConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseIfsConnector {
+class DeletePropertyAnnualSubmissionConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseIfsConnector {
 
-  def deleteForeignPropertyAnnualSubmission(
-      request: DeletePropertyAnnualSubmissionRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext, correlationId: String): Future[IfsOutcome[Unit]] = {
+  def deletePropertyAnnualSubmission(request: DeletePropertyAnnualSubmissionRequest)(implicit hc: HeaderCarrier,
+                                                                                     ec: ExecutionContext,
+                                                                                     correlationId: String): Future[IfsOutcome[Unit]] = {
 
     delete(
-      uri = IfsUri[Unit](s"income-tax/business/property/annual/${request.nino.nino}/${request.businessId}/${request.taxYear}")
+      uri = IfsUri[Unit](
+        s"income-tax/business/property/annual?taxableEntityId=${request.nino.nino}&incomeSourceId=${request.businessId}&taxYear=${request.taxYear}")
     )
   }
 }

--- a/app/v2/controllers/DeleteForeignPropertyAnnualSubmissionController.scala
+++ b/app/v2/controllers/DeleteForeignPropertyAnnualSubmissionController.scala
@@ -27,7 +27,7 @@ import v2.controllers.requestParsers.DeleteForeignPropertyAnnualSubmissionReques
 import v2.models.audit.{ AuditEvent, AuditResponse, DeleteForeignPropertyAnnualAuditDetail }
 import v2.models.errors._
 import v2.models.request.deletePropertyAnnualSubmission.DeletePropertyAnnualSubmissionRawData
-import v2.services.{ AuditService, DeleteForeignPropertyAnnualSubmissionService, EnrolmentsAuthService, MtdIdLookupService }
+import v2.services.{ AuditService, DeletePropertyAnnualSubmissionService, EnrolmentsAuthService, MtdIdLookupService }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -35,7 +35,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 class DeleteForeignPropertyAnnualSubmissionController @Inject()(val authService: EnrolmentsAuthService,
                                                                 val lookupService: MtdIdLookupService,
                                                                 parser: DeleteForeignPropertyAnnualSubmissionRequestParser,
-                                                                service: DeleteForeignPropertyAnnualSubmissionService,
+                                                                service: DeletePropertyAnnualSubmissionService,
                                                                 auditService: AuditService,
                                                                 cc: ControllerComponents,
                                                                 idGenerator: IdGenerator)(implicit ec: ExecutionContext)
@@ -56,7 +56,7 @@ class DeleteForeignPropertyAnnualSubmissionController @Inject()(val authService:
       val result =
         for {
           parsedRequest   <- EitherT.fromEither[Future](parser.parseRequest(rawData))
-          serviceResponse <- EitherT(service.deleteForeignPropertyAnnualSubmission(parsedRequest))
+          serviceResponse <- EitherT(service.deletePropertyAnnualSubmission(parsedRequest))
         } yield {
           logger.info(
             s"[${endpointLogContext.controllerName}][${endpointLogContext.endpointName}] - " +

--- a/app/v2/services/AmendForeignPropertyAnnualSubmissionService.scala
+++ b/app/v2/services/AmendForeignPropertyAnnualSubmissionService.scala
@@ -37,7 +37,7 @@ class AmendForeignPropertyAnnualSubmissionService @Inject()(connector: AmendFore
     implicit hc: HeaderCarrier,
     ec: ExecutionContext,
     logContext: EndpointLogContext,
-    correlationId: String): Future[AmendForeignPropertyAnnualSubmissionServiceOutcome] = {
+    correlationId: String): Future[ServiceOutcome[Unit]] = {
 
     val result = for {
       ifsResponseWrapper <- EitherT(connector.amendForeignPropertyAnnualSubmission(request)).leftMap(mapIfsErrors(ifsErrorMap))

--- a/app/v2/services/AmendForeignPropertyPeriodSummaryService.scala
+++ b/app/v2/services/AmendForeignPropertyPeriodSummaryService.scala
@@ -38,7 +38,7 @@ class AmendForeignPropertyPeriodSummaryService @Inject()(connector: AmendForeign
     implicit hc: HeaderCarrier,
     ec: ExecutionContext,
     logContext: EndpointLogContext,
-    correlationId: String): Future[AmendForeignPropertyPeriodSummaryServiceOutcome] = {
+    correlationId: String): Future[ServiceOutcome[Unit]] = {
 
     val result = for {
       ifsResponseWrapper <- EitherT(connector.amendForeignProperty(request)).leftMap(mapIfsErrors(ifsErrorMap))

--- a/app/v2/services/CreateForeignPropertyPeriodSummaryService.scala
+++ b/app/v2/services/CreateForeignPropertyPeriodSummaryService.scala
@@ -18,6 +18,7 @@ package v2.services
 
 import cats.implicits._
 import cats.data.EitherT
+
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.Logging
@@ -25,6 +26,7 @@ import v2.connectors.CreateForeignPropertyPeriodSummaryConnector
 import v2.controllers.EndpointLogContext
 import v2.models.errors._
 import v2.models.request.createForeignPropertyPeriodSummary.CreateForeignPropertyPeriodSummaryRequest
+import v2.models.response.createForeignPropertyPeriodSummary.CreateForeignPropertyPeriodSummaryResponse
 import v2.support.IfsResponseMappingSupport
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,7 +39,7 @@ class CreateForeignPropertyPeriodSummaryService @Inject()(connector: CreateForei
     implicit hc: HeaderCarrier,
     ec: ExecutionContext,
     logContext: EndpointLogContext,
-    correlationId: String): Future[CreateForeignPropertyPeriodSummaryServiceOutcome] = {
+    correlationId: String): Future[ServiceOutcome[CreateForeignPropertyPeriodSummaryResponse]] = {
 
     val result = for {
       ifsResponseWrapper <- EitherT(connector.createForeignProperty(request)).leftMap(mapIfsErrors(ifsErrorMap))

--- a/app/v2/services/DeletePropertyAnnualSubmissionService.scala
+++ b/app/v2/services/DeletePropertyAnnualSubmissionService.scala
@@ -18,30 +18,31 @@ package v2.services
 
 import cats.implicits._
 import cats.data.EitherT
+
 import javax.inject.{ Inject, Singleton }
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.Logging
-import v2.connectors.DeleteForeignPropertyAnnualSubmissionConnector
+import v2.connectors.DeletePropertyAnnualSubmissionConnector
 import v2.controllers.EndpointLogContext
-import v2.models.errors.{ BusinessIdFormatError, DownstreamError, NinoFormatError, NotFoundError }
+import v2.models.errors.{ BusinessIdFormatError, DownstreamError, NinoFormatError, NotFoundError, TaxYearFormatError }
 import v2.models.request.deletePropertyAnnualSubmission.DeletePropertyAnnualSubmissionRequest
 import v2.support.IfsResponseMappingSupport
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton
-class DeleteForeignPropertyAnnualSubmissionService @Inject()(connector: DeleteForeignPropertyAnnualSubmissionConnector)
+class DeletePropertyAnnualSubmissionService @Inject()(connector: DeletePropertyAnnualSubmissionConnector)
     extends IfsResponseMappingSupport
     with Logging {
 
-  def deleteForeignPropertyAnnualSubmission(request: DeletePropertyAnnualSubmissionRequest)(
+  def deletePropertyAnnualSubmission(request: DeletePropertyAnnualSubmissionRequest)(
       implicit hc: HeaderCarrier,
       ec: ExecutionContext,
       logContext: EndpointLogContext,
-      correlationId: String): Future[DeleteForeignPropertyAnnualSubmissionServiceOutcome] = {
+      correlationId: String): Future[ServiceOutcome[Unit]] = {
 
     val result = for {
-      ifsResponseWrapper <- EitherT(connector.deleteForeignPropertyAnnualSubmission(request)).leftMap(mapIfsErrors(ifsErrorMap))
+      ifsResponseWrapper <- EitherT(connector.deletePropertyAnnualSubmission(request)).leftMap(mapIfsErrors(ifsErrorMap))
     } yield ifsResponseWrapper
 
     result.value
@@ -50,8 +51,8 @@ class DeleteForeignPropertyAnnualSubmissionService @Inject()(connector: DeleteFo
   private def ifsErrorMap =
     Map(
       "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
-      "INVALID_INCOME_SOURCE_ID"  -> BusinessIdFormatError,
-      "INVALID_TAX_YEAR"          -> DownstreamError,
+      "INVALID_TAX_YEAR"          -> TaxYearFormatError,
+      "INVALID_INCOMESOURCEID"    -> BusinessIdFormatError,
       "INVALID_CORRELATIONID"     -> DownstreamError,
       "NO_DATA_FOUND"             -> NotFoundError,
       "SERVER_ERROR"              -> DownstreamError,

--- a/app/v2/services/ListForeignPropertiesPeriodSummariesService.scala
+++ b/app/v2/services/ListForeignPropertiesPeriodSummariesService.scala
@@ -18,6 +18,7 @@ package v2.services
 
 import cats.data.EitherT
 import cats.implicits._
+
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.Logging
@@ -25,6 +26,7 @@ import v2.connectors.ListForeignPropertiesPeriodSummariesConnector
 import v2.controllers.EndpointLogContext
 import v2.models.errors._
 import v2.models.request.listForeignPropertiesPeriodSummaries.ListForeignPropertiesPeriodSummariesRequest
+import v2.models.response.listForeignPropertiesPeriodSummaries.{ListForeignPropertiesPeriodSummariesResponse, SubmissionPeriod}
 import v2.support.IfsResponseMappingSupport
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,7 +39,7 @@ class ListForeignPropertiesPeriodSummariesService @Inject()(connector: ListForei
     implicit hc: HeaderCarrier,
     ec: ExecutionContext,
     logContext: EndpointLogContext,
-    correlationId: String): Future[ListForeignPropertiesPeriodSummariesServiceOutcome] = {
+    correlationId: String): Future[ServiceOutcome[ListForeignPropertiesPeriodSummariesResponse[SubmissionPeriod]]] = {
 
     val result = for {
       ifsResponseWrapper <- EitherT(connector.listForeignProperties(request)).leftMap(mapIfsErrors(ifsErrorMap))

--- a/app/v2/services/RetrieveForeignPropertyAnnualSubmissionService.scala
+++ b/app/v2/services/RetrieveForeignPropertyAnnualSubmissionService.scala
@@ -18,6 +18,7 @@ package v2.services
 
 import cats.implicits._
 import cats.data.EitherT
+
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.Logging
@@ -25,6 +26,7 @@ import v2.connectors.RetrieveForeignPropertyAnnualSubmissionConnector
 import v2.controllers.EndpointLogContext
 import v2.models.errors.{BusinessIdFormatError, DownstreamError, NinoFormatError, NotFoundError}
 import v2.models.request.retrieveForeignPropertyAnnualSubmission.RetrieveForeignPropertyAnnualSubmissionRequest
+import v2.models.response.retrieveForeignPropertyAnnualSubmission.RetrieveForeignPropertyAnnualSubmissionResponse
 import v2.support.IfsResponseMappingSupport
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,7 +39,7 @@ class RetrieveForeignPropertyAnnualSubmissionService @Inject()(connector: Retrie
     implicit hc: HeaderCarrier,
     ec: ExecutionContext,
     logContext: EndpointLogContext,
-    correlationId: String): Future[RetrieveForeignPropertyAnnualSubmissionServiceOutcome] = {
+    correlationId: String): Future[ServiceOutcome[RetrieveForeignPropertyAnnualSubmissionResponse]] = {
 
     val result = for {
       ifsResponseWrapper <- EitherT(connector.retrieveForeignProperty(request)).leftMap(mapIfsErrors(ifsErrorMap))

--- a/app/v2/services/RetrieveForeignPropertyPeriodSummaryService.scala
+++ b/app/v2/services/RetrieveForeignPropertyPeriodSummaryService.scala
@@ -18,6 +18,7 @@ package v2.services
 
 import cats.implicits._
 import cats.data.EitherT
+
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.Logging
@@ -25,6 +26,7 @@ import v2.connectors.RetrieveForeignPropertyPeriodSummaryConnector
 import v2.controllers.EndpointLogContext
 import v2.models.errors._
 import v2.models.request.retrieveForeignPropertyPeriodSummary.RetrieveForeignPropertyPeriodSummaryRequest
+import v2.models.response.retrieveForeignPropertyPeriodSummary.RetrieveForeignPropertyPeriodSummaryResponse
 import v2.support.IfsResponseMappingSupport
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,7 +39,7 @@ class RetrieveForeignPropertyPeriodSummaryService @Inject()(connector: RetrieveF
     implicit hc: HeaderCarrier,
     ec: ExecutionContext,
     logContext: EndpointLogContext,
-    correlationId: String): Future[RetrieveForeignPropertyPeriodSummaryServiceOutcome] = {
+    correlationId: String): Future[ServiceOutcome[RetrieveForeignPropertyPeriodSummaryResponse]] = {
 
     val result = for {
       ifsResponseWrapper <- EitherT(connector.retrieveForeignProperty(request)).leftMap(mapIfsErrors(ifsErrorMap))

--- a/app/v2/services/package.scala
+++ b/app/v2/services/package.scala
@@ -18,27 +18,9 @@ package v2
 
 import v2.models.errors.ErrorWrapper
 import v2.models.outcomes.ResponseWrapper
-import v2.models.response.listForeignPropertiesPeriodSummaries.{ ListForeignPropertiesPeriodSummariesResponse, SubmissionPeriod }
-import v2.models.response.createForeignPropertyPeriodSummary.CreateForeignPropertyPeriodSummaryResponse
-import v2.models.response.retrieveForeignPropertyAnnualSubmission.RetrieveForeignPropertyAnnualSubmissionResponse
-import v2.models.response.retrieveForeignPropertyPeriodSummary.RetrieveForeignPropertyPeriodSummaryResponse
 
 package object services {
 
   type ServiceOutcome[A] = Either[ErrorWrapper, ResponseWrapper[A]]
-
-  type CreateForeignPropertyPeriodSummaryServiceOutcome = ServiceOutcome[CreateForeignPropertyPeriodSummaryResponse]
-
-  type AmendForeignPropertyPeriodSummaryServiceOutcome = ServiceOutcome[Unit]
-
-  type RetrieveForeignPropertyPeriodSummaryServiceOutcome = ServiceOutcome[RetrieveForeignPropertyPeriodSummaryResponse]
-
-  type RetrieveForeignPropertyAnnualSubmissionServiceOutcome = ServiceOutcome[RetrieveForeignPropertyAnnualSubmissionResponse]
-
-  type ListForeignPropertiesPeriodSummariesServiceOutcome = ServiceOutcome[ListForeignPropertiesPeriodSummariesResponse[SubmissionPeriod]]
-
-  type AmendForeignPropertyAnnualSubmissionServiceOutcome = ServiceOutcome[Unit]
-
-  type DeleteForeignPropertyAnnualSubmissionServiceOutcome = ServiceOutcome[Unit]
 
 }

--- a/test/v2/connectors/DeletePropertyAnnualSubmissionConnectorSpec.scala
+++ b/test/v2/connectors/DeletePropertyAnnualSubmissionConnectorSpec.scala
@@ -24,7 +24,7 @@ import v2.models.request.deletePropertyAnnualSubmission.DeletePropertyAnnualSubm
 
 import scala.concurrent.Future
 
-class DeleteForeignPropertyAnnualSubmissionConnectorSpec extends ConnectorSpec {
+class DeletePropertyAnnualSubmissionConnectorSpec extends ConnectorSpec {
 
   val nino: String       = "AA123456A"
   val businessId: String = "XAIS12345678910"
@@ -38,7 +38,7 @@ class DeleteForeignPropertyAnnualSubmissionConnectorSpec extends ConnectorSpec {
 
   class Test extends MockHttpClient with MockAppConfig {
 
-    val connector: DeleteForeignPropertyAnnualSubmissionConnector = new DeleteForeignPropertyAnnualSubmissionConnector(
+    val connector: DeletePropertyAnnualSubmissionConnector = new DeletePropertyAnnualSubmissionConnector(
       http = mockHttpClient,
       appConfig = mockAppConfig
     )
@@ -55,14 +55,14 @@ class DeleteForeignPropertyAnnualSubmissionConnectorSpec extends ConnectorSpec {
 
       MockHttpClient
         .delete(
-          url = s"$baseUrl/income-tax/business/property/annual/$nino/$businessId/$taxYear",
+          url = s"$baseUrl/income-tax/business/property/annual?taxableEntityId=$nino&incomeSourceId=$businessId&taxYear=$taxYear",
           config = dummyIfsHeaderCarrierConfig,
           requiredHeaders = requiredIfsHeaders,
           excludedHeaders = Seq("AnotherHeader" -> "HeaderValue")
         )
         .returns(Future.successful(outcome))
 
-      await(connector.deleteForeignPropertyAnnualSubmission(request)) shouldBe outcome
+      await(connector.deletePropertyAnnualSubmission(request)) shouldBe outcome
 
     }
   }

--- a/test/v2/controllers/DeleteForeignPropertyAnnualSubmissionControllerSpec.scala
+++ b/test/v2/controllers/DeleteForeignPropertyAnnualSubmissionControllerSpec.scala
@@ -21,7 +21,7 @@ import play.api.mvc.Result
 import uk.gov.hmrc.http.HeaderCarrier
 import v2.mocks.MockIdGenerator
 import v2.mocks.requestParsers.MockDeleteForeignPropertyAnnualSubmissionRequestParser
-import v2.mocks.services.{ MockAuditService, MockDeleteForeignPropertyAnnualSubmissionService, MockEnrolmentsAuthService, MockMtdIdLookupService }
+import v2.mocks.services.{ MockAuditService, MockDeletePropertyAnnualSubmissionService, MockEnrolmentsAuthService, MockMtdIdLookupService }
 import v2.models.audit.{ AuditError, AuditEvent, AuditResponse, DeleteForeignPropertyAnnualAuditDetail }
 import v2.models.domain.Nino
 import v2.models.errors._
@@ -35,7 +35,7 @@ class DeleteForeignPropertyAnnualSubmissionControllerSpec
     extends ControllerBaseSpec
     with MockEnrolmentsAuthService
     with MockMtdIdLookupService
-    with MockDeleteForeignPropertyAnnualSubmissionService
+    with MockDeletePropertyAnnualSubmissionService
     with MockDeleteForeignPropertyAnnualSubmissionRequestParser
     with MockAuditService
     with MockIdGenerator {

--- a/test/v2/mocks/connectors/MockDeletePropertyAnnualSubmissionConnector.scala
+++ b/test/v2/mocks/connectors/MockDeletePropertyAnnualSubmissionConnector.scala
@@ -19,22 +19,22 @@ package v2.mocks.connectors
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.http.HeaderCarrier
-import v2.connectors.{ DeleteForeignPropertyAnnualSubmissionConnector, IfsOutcome }
+import v2.connectors.{ DeletePropertyAnnualSubmissionConnector, IfsOutcome }
 import v2.models.request.deletePropertyAnnualSubmission.DeletePropertyAnnualSubmissionRequest
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-trait MockDeleteForeignPropertyAnnualSubmissionConnector extends MockFactory {
+trait MockDeletePropertyAnnualSubmissionConnector extends MockFactory {
 
-  val mockDeleteForeignPropertyAnnualSubmissionConnector: DeleteForeignPropertyAnnualSubmissionConnector =
-    mock[DeleteForeignPropertyAnnualSubmissionConnector]
+  val mockDeleteForeignPropertyAnnualSubmissionConnector: DeletePropertyAnnualSubmissionConnector =
+    mock[DeletePropertyAnnualSubmissionConnector]
 
   object MockDeleteForeignPropertyAnnualSubmissionConnector {
 
     def deleteForeignProperty(requestData: DeletePropertyAnnualSubmissionRequest): CallHandler[Future[IfsOutcome[Unit]]] = {
       (
         mockDeleteForeignPropertyAnnualSubmissionConnector
-          .deleteForeignPropertyAnnualSubmission(_: DeletePropertyAnnualSubmissionRequest)(
+          .deletePropertyAnnualSubmission(_: DeletePropertyAnnualSubmissionRequest)(
             _: HeaderCarrier,
             _: ExecutionContext,
             _: String

--- a/test/v2/mocks/services/MockDeletePropertyAnnualSubmissionService.scala
+++ b/test/v2/mocks/services/MockDeletePropertyAnnualSubmissionService.scala
@@ -23,14 +23,14 @@ import v2.controllers.EndpointLogContext
 import v2.models.errors.ErrorWrapper
 import v2.models.outcomes.ResponseWrapper
 import v2.models.request.deletePropertyAnnualSubmission.DeletePropertyAnnualSubmissionRequest
-import v2.services.DeleteForeignPropertyAnnualSubmissionService
+import v2.services.DeletePropertyAnnualSubmissionService
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-trait MockDeleteForeignPropertyAnnualSubmissionService extends MockFactory {
+trait MockDeletePropertyAnnualSubmissionService extends MockFactory {
 
-  val mockDeleteForeignPropertyAnnualSubmissionService: DeleteForeignPropertyAnnualSubmissionService =
-    mock[DeleteForeignPropertyAnnualSubmissionService]
+  val mockDeleteForeignPropertyAnnualSubmissionService: DeletePropertyAnnualSubmissionService =
+    mock[DeletePropertyAnnualSubmissionService]
 
   object MockDeleteForeignPropertyAnnualSubmissionService {
 
@@ -38,7 +38,7 @@ trait MockDeleteForeignPropertyAnnualSubmissionService extends MockFactory {
         requestData: DeletePropertyAnnualSubmissionRequest): CallHandler[Future[Either[ErrorWrapper, ResponseWrapper[Unit]]]] = {
       (
         mockDeleteForeignPropertyAnnualSubmissionService
-          .deleteForeignPropertyAnnualSubmission(_: DeletePropertyAnnualSubmissionRequest)(
+          .deletePropertyAnnualSubmission(_: DeletePropertyAnnualSubmissionRequest)(
             _: HeaderCarrier,
             _: ExecutionContext,
             _: EndpointLogContext,

--- a/test/v2/services/DeletePropertyAnnualSubmissionServiceSpec.scala
+++ b/test/v2/services/DeletePropertyAnnualSubmissionServiceSpec.scala
@@ -19,7 +19,7 @@ package v2.services
 import support.UnitSpec
 import uk.gov.hmrc.http.HeaderCarrier
 import v2.controllers.EndpointLogContext
-import v2.mocks.connectors.MockDeleteForeignPropertyAnnualSubmissionConnector
+import v2.mocks.connectors.MockDeletePropertyAnnualSubmissionConnector
 import v2.models.domain.Nino
 import v2.models.errors._
 import v2.models.outcomes.ResponseWrapper
@@ -28,7 +28,7 @@ import v2.models.request.deletePropertyAnnualSubmission.DeletePropertyAnnualSubm
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class DeleteForeignPropertyAnnualSubmissionServiceSpec extends UnitSpec {
+class DeletePropertyAnnualSubmissionServiceSpec extends UnitSpec {
 
   val nino: String                   = "AA123456A"
   val businessId: String             = "XAIS12345678910"
@@ -37,51 +37,51 @@ class DeleteForeignPropertyAnnualSubmissionServiceSpec extends UnitSpec {
 
   private val requestData = DeletePropertyAnnualSubmissionRequest(Nino(nino), businessId, taxYear)
 
-  trait Test extends MockDeleteForeignPropertyAnnualSubmissionConnector {
+  trait Test extends MockDeletePropertyAnnualSubmissionConnector {
     implicit val hc: HeaderCarrier              = HeaderCarrier()
     implicit val logContext: EndpointLogContext = EndpointLogContext("c", "ep")
 
-    val service = new DeleteForeignPropertyAnnualSubmissionService(
+    val service = new DeletePropertyAnnualSubmissionService(
       connector = mockDeleteForeignPropertyAnnualSubmissionConnector
     )
   }
 
-  "service" should {
-    "service call successful" when {
+  "service" when {
+    "service call successful" should {
       "return mapped result" in new Test {
         MockDeleteForeignPropertyAnnualSubmissionConnector
           .deleteForeignProperty(requestData)
           .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
 
-        await(service.deleteForeignPropertyAnnualSubmission(requestData)) shouldBe Right(ResponseWrapper(correlationId, ()))
+        await(service.deletePropertyAnnualSubmission(requestData)) shouldBe Right(ResponseWrapper(correlationId, ()))
       }
     }
-  }
 
-  "unsuccessful" should {
-    "map errors according to spec" when {
+    "unsuccessful" should {
+      "map errors according to spec" when {
 
-      def serviceError(ifsErrorCode: String, error: MtdError): Unit =
-        s"a $ifsErrorCode error is returned from the service" in new Test {
+        def serviceError(ifsErrorCode: String, error: MtdError): Unit =
+          s"a $ifsErrorCode error is returned from the service" in new Test {
 
-          MockDeleteForeignPropertyAnnualSubmissionConnector
-            .deleteForeignProperty(requestData)
-            .returns(Future.successful(Left(ResponseWrapper(correlationId, IfsErrors.single(IfsErrorCode(ifsErrorCode))))))
+            MockDeleteForeignPropertyAnnualSubmissionConnector
+              .deleteForeignProperty(requestData)
+              .returns(Future.successful(Left(ResponseWrapper(correlationId, IfsErrors.single(IfsErrorCode(ifsErrorCode))))))
 
-          await(service.deleteForeignPropertyAnnualSubmission(requestData)) shouldBe Left(ErrorWrapper(correlationId, error))
-        }
+            await(service.deletePropertyAnnualSubmission(requestData)) shouldBe Left(ErrorWrapper(correlationId, error))
+          }
 
-      val input = Seq(
-        "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
-        "INVALID_INCOME_SOURCE_ID"  -> BusinessIdFormatError,
-        "INVALID_TAX_YEAR"          -> DownstreamError,
-        "INVALID_CORRELATIONID"     -> DownstreamError,
-        "NO_DATA_FOUND"             -> NotFoundError,
-        "SERVER_ERROR"              -> DownstreamError,
-        "SERVICE_UNAVAILABLE"       -> DownstreamError
-      )
+        val input = Seq(
+          "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+          "INVALID_TAX_YEAR"          -> TaxYearFormatError,
+          "INVALID_INCOMESOURCEID"    -> BusinessIdFormatError,
+          "INVALID_CORRELATIONID"     -> DownstreamError,
+          "NO_DATA_FOUND"             -> NotFoundError,
+          "SERVER_ERROR"              -> DownstreamError,
+          "SERVICE_UNAVAILABLE"       -> DownstreamError
+        )
 
-      input.foreach(args => (serviceError _).tupled(args))
+        input.foreach(args => (serviceError _).tupled(args))
+      }
     }
   }
 }


### PR DESCRIPTION
- rename existing foreign connector/service code
- fix service errors
- fix connector url and query params
- remove obscuring ServiceOutcome type aliases that are used only once
- fix ISpec to pass tests (correct query params and errors)