### PR TITLE
Simplify create historic period responses and periodId

### DIFF
--- a/app/v2/connectors/CreateHistoricFhlUkPiePeriodSummaryConnector.scala
+++ b/app/v2/connectors/CreateHistoricFhlUkPiePeriodSummaryConnector.scala
@@ -17,11 +17,11 @@
 package v2.connectors
 
 import config.AppConfig
+import play.api.http.Status
 import uk.gov.hmrc.http.{ HeaderCarrier, HttpClient }
 import v2.connectors.DownstreamUri.IfsUri
 import v2.connectors.httpparsers.StandardIfsHttpParser._
 import v2.models.request.createHistoricFhlUkPiePeriodSummary.CreateHistoricFhlUkPiePeriodSummaryRequest
-import v2.models.response.createHistoricFhlUkPiePeriodSummary.CreateHistoricFhlUkPiePeriodSummaryResponse
 
 import javax.inject.{ Inject, Singleton }
 import scala.concurrent.{ ExecutionContext, Future }
@@ -29,12 +29,13 @@ import scala.concurrent.{ ExecutionContext, Future }
 @Singleton
 class CreateHistoricFhlUkPiePeriodSummaryConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
 
-  def createPeriodSummary(request: CreateHistoricFhlUkPiePeriodSummaryRequest)(
-      implicit hc: HeaderCarrier,
-      ex: ExecutionContext,
-      correlationId: String): Future[DownstreamOutcome[CreateHistoricFhlUkPiePeriodSummaryResponse]] = {
+  implicit val successCode: SuccessCode = SuccessCode(Status.OK)
+
+  def createPeriodSummary(request: CreateHistoricFhlUkPiePeriodSummaryRequest)(implicit hc: HeaderCarrier,
+                                                                               ex: ExecutionContext,
+                                                                               correlationId: String): Future[DownstreamOutcome[Unit]] = {
 
     val path = s"income-tax/nino/${request.nino.nino}/uk-properties/furnished-holiday-lettings/periodic-summaries"
-    post(request.body, IfsUri[CreateHistoricFhlUkPiePeriodSummaryResponse](path))
+    post(request.body, IfsUri[Unit](path))
   }
 }

--- a/app/v2/connectors/CreateHistoricNonFhlUkPropertyPeriodSummaryConnector.scala
+++ b/app/v2/connectors/CreateHistoricNonFhlUkPropertyPeriodSummaryConnector.scala
@@ -16,25 +16,26 @@
 
 package v2.connectors
 
-import javax.inject.{ Inject, Singleton }
 import config.AppConfig
+import play.api.http.Status
 import uk.gov.hmrc.http.{ HeaderCarrier, HttpClient }
 import v2.connectors.DownstreamUri.IfsUri
 import v2.connectors.httpparsers.StandardIfsHttpParser._
 import v2.models.request.createHistoricNonFhlUkPropertyPeriodSummary.CreateHistoricNonFhlUkPropertyPeriodSummaryRequest
-import v2.models.response.createHistoricNonFhlUkPiePeriodSummary.CreateHistoricNonFhlUkPiePeriodSummaryResponse
 
+import javax.inject.{ Inject, Singleton }
 import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton
 class CreateHistoricNonFhlUkPropertyPeriodSummaryConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
 
-  def createPeriodSummary(request: CreateHistoricNonFhlUkPropertyPeriodSummaryRequest)(
-      implicit hc: HeaderCarrier,
-      ex: ExecutionContext,
-      correlationId: String): Future[DownstreamOutcome[CreateHistoricNonFhlUkPiePeriodSummaryResponse]] = {
+  implicit val successCode: SuccessCode = SuccessCode(Status.OK)
+
+  def createPeriodSummary(request: CreateHistoricNonFhlUkPropertyPeriodSummaryRequest)(implicit hc: HeaderCarrier,
+                                                                                       ex: ExecutionContext,
+                                                                                       correlationId: String): Future[DownstreamOutcome[Unit]] = {
 
     val path = s"income-tax/nino/${request.nino.nino}/uk-properties/other/periodic-summaries"
-    post(request.body, IfsUri[CreateHistoricNonFhlUkPiePeriodSummaryResponse](path))
+    post(request.body, IfsUri[Unit](path))
   }
 }

--- a/app/v2/controllers/CreateHistoricFhlUkPiePeriodSummaryController.scala
+++ b/app/v2/controllers/CreateHistoricFhlUkPiePeriodSummaryController.scala
@@ -68,9 +68,7 @@ class CreateHistoricFhlUkPiePeriodSummaryController @Inject()(val authService: E
             hateoasFactory
               .wrap(
                 serviceResponse.responseData,
-                CreateHistoricFhlUkPiePeriodSummaryHateoasData(nino,
-                                                               s"${parsedRequest.body.fromDate}_${parsedRequest.body.toDate}",
-                                                               serviceResponse.responseData.transactionReference)
+                CreateHistoricFhlUkPiePeriodSummaryHateoasData(nino, serviceResponse.responseData.periodId)
               )
               .asRight[ErrorWrapper]
           )

--- a/app/v2/controllers/CreateHistoricNonFHLUkPiePeriodSummaryController.scala
+++ b/app/v2/controllers/CreateHistoricNonFHLUkPiePeriodSummaryController.scala
@@ -24,7 +24,7 @@ import utils.{ IdGenerator, Logging }
 import v2.controllers.requestParsers.CreateHistoricNonFhlUkPropertyPeriodSummaryRequestParser
 import v2.hateoas.HateoasFactory
 import v2.models.errors._
-import v2.models.request.createHistoricNonFhlUkPropertyPeriodSummary.{ CreateHistoricNonFhlUkPropertyPeriodSummaryRawData }
+import v2.models.request.createHistoricNonFhlUkPropertyPeriodSummary.CreateHistoricNonFhlUkPropertyPeriodSummaryRawData
 import v2.models.response.createHistoricNonFhlUkPiePeriodSummary.CreateHistoricNonFhlUkPiePeriodSummaryHateoasData
 import v2.services.{ CreateHistoricNonFhlUkPropertyPeriodSummaryService, EnrolmentsAuthService, MtdIdLookupService }
 
@@ -66,9 +66,7 @@ class CreateHistoricNonFHLUkPiePeriodSummaryController @Inject()(val authService
             hateoasFactory
               .wrap(
                 serviceResponse.responseData,
-                CreateHistoricNonFhlUkPiePeriodSummaryHateoasData(nino,
-                                                                  s"${parsedRequest.body.fromDate}_${parsedRequest.body.toDate}",
-                                                                  serviceResponse.responseData.transactionReference)
+                CreateHistoricNonFhlUkPiePeriodSummaryHateoasData(nino, serviceResponse.responseData.periodId)
               )
               .asRight[ErrorWrapper])
         } yield {
@@ -113,8 +111,8 @@ class CreateHistoricNonFHLUkPiePeriodSummaryController @Inject()(val authService
             RuleHistoricTaxYearNotSupportedError,
           ) =>
         BadRequest(Json.toJson(errorWrapper))
-      case NotFoundError                             => NotFound(Json.toJson(errorWrapper))
-      case (ServiceUnavailableError | InternalError) => InternalServerError(Json.toJson(errorWrapper))
-      case _                                         => unhandledError(errorWrapper)
+      case NotFoundError                           => NotFound(Json.toJson(errorWrapper))
+      case ServiceUnavailableError | InternalError => InternalServerError(Json.toJson(errorWrapper))
+      case _                                       => unhandledError(errorWrapper)
     }
 }

--- a/app/v2/models/domain/PeriodId.scala
+++ b/app/v2/models/domain/PeriodId.scala
@@ -16,6 +16,8 @@
 
 package v2.models.domain
 
+import play.api.libs.json.{ JsString, Writes }
+
 case class PeriodId(value: String) {
 
   val (from, to): (String, String) = {
@@ -31,6 +33,7 @@ case class PeriodId(value: String) {
 }
 
 object PeriodId {
+  implicit val writes: Writes[PeriodId] = Writes(x => JsString(x.value))
 
   def apply(from: String, to: String): PeriodId = {
     PeriodId(s"${from}_$to")

--- a/app/v2/models/response/createHistoricFhlUkPiePeriodSummary/CreateHistoricFhlUkPiePeriodSummaryResponse.scala
+++ b/app/v2/models/response/createHistoricFhlUkPiePeriodSummary/CreateHistoricFhlUkPiePeriodSummaryResponse.scala
@@ -19,30 +19,25 @@ package v2.models.response.createHistoricFhlUkPiePeriodSummary
 import config.AppConfig
 import play.api.libs.json._
 import v2.hateoas.{ HateoasLinks, HateoasLinksFactory }
+import v2.models.domain.PeriodId
 import v2.models.hateoas.{ HateoasData, Link }
 
-case class CreateHistoricFhlUkPiePeriodSummaryResponse(transactionReference: String, periodId: Option[String])
+case class CreateHistoricFhlUkPiePeriodSummaryResponse(periodId: PeriodId)
 
 object CreateHistoricFhlUkPiePeriodSummaryResponse extends HateoasLinks {
 
-  implicit val writes: OWrites[CreateHistoricFhlUkPiePeriodSummaryResponse] = OWrites { response =>
-    response.periodId
-      .map(periodId => Json.obj("periodId" -> periodId))
-      .getOrElse(JsObject.empty)
-  }
-
-  implicit val reads: Reads[CreateHistoricFhlUkPiePeriodSummaryResponse] = Json.reads[CreateHistoricFhlUkPiePeriodSummaryResponse]
+  implicit val writes: OWrites[CreateHistoricFhlUkPiePeriodSummaryResponse] = Json.writes
 
   implicit object LinksFactory
       extends HateoasLinksFactory[CreateHistoricFhlUkPiePeriodSummaryResponse, CreateHistoricFhlUkPiePeriodSummaryHateoasData] {
     override def links(appConfig: AppConfig, data: CreateHistoricFhlUkPiePeriodSummaryHateoasData): Seq[Link] = {
       import data._
       Seq(
-        amendHistoricFhlUkPiePeriodSummary(appConfig, nino, periodId),
-        retrieveHistoricFhlUkPiePeriodSummary(appConfig, nino, periodId)
+        amendHistoricFhlUkPiePeriodSummary(appConfig, nino, periodId.value),
+        retrieveHistoricFhlUkPiePeriodSummary(appConfig, nino, periodId.value)
       )
     }
   }
 }
 
-case class CreateHistoricFhlUkPiePeriodSummaryHateoasData(nino: String, periodId: String, transactionId: String) extends HateoasData
+case class CreateHistoricFhlUkPiePeriodSummaryHateoasData(nino: String, periodId: PeriodId) extends HateoasData

--- a/app/v2/models/response/createHistoricNonFhlUkPiePeriodSummary/CreateHistoricNonFhlUkPiePeriodSummaryResponse.scala
+++ b/app/v2/models/response/createHistoricNonFhlUkPiePeriodSummary/CreateHistoricNonFhlUkPiePeriodSummaryResponse.scala
@@ -17,32 +17,27 @@
 package v2.models.response.createHistoricNonFhlUkPiePeriodSummary
 
 import config.AppConfig
-import play.api.libs.json.{ JsObject, Json, OWrites, Reads }
+import play.api.libs.json.{ Json, OWrites }
 import v2.hateoas.{ HateoasLinks, HateoasLinksFactory }
+import v2.models.domain.PeriodId
 import v2.models.hateoas.{ HateoasData, Link }
 
-case class CreateHistoricNonFhlUkPiePeriodSummaryResponse(transactionReference: String, periodId: Option[String])
+case class CreateHistoricNonFhlUkPiePeriodSummaryResponse(periodId: PeriodId)
 
 object CreateHistoricNonFhlUkPiePeriodSummaryResponse extends HateoasLinks {
 
-  implicit val writes: OWrites[CreateHistoricNonFhlUkPiePeriodSummaryResponse] = OWrites { response =>
-    response.periodId
-      .map(periodId => Json.obj("periodId" -> periodId))
-      .getOrElse(JsObject.empty)
-  }
-
-  implicit val reads: Reads[CreateHistoricNonFhlUkPiePeriodSummaryResponse] = Json.reads[CreateHistoricNonFhlUkPiePeriodSummaryResponse]
+  implicit val writes: OWrites[CreateHistoricNonFhlUkPiePeriodSummaryResponse] = Json.writes
 
   implicit object LinksFactory
       extends HateoasLinksFactory[CreateHistoricNonFhlUkPiePeriodSummaryResponse, CreateHistoricNonFhlUkPiePeriodSummaryHateoasData] {
     override def links(appConfig: AppConfig, data: CreateHistoricNonFhlUkPiePeriodSummaryHateoasData): Seq[Link] = {
       import data._
       Seq(
-        retrieveHistoricNonFhlUkPiePeriodSummary(appConfig: AppConfig, nino: String, periodId: String),
-        amendHistoricNonFhlUkPiePeriodSummary(appConfig: AppConfig, nino: String, periodId: String)
+        retrieveHistoricNonFhlUkPiePeriodSummary(appConfig, nino, periodId.value),
+        amendHistoricNonFhlUkPiePeriodSummary(appConfig, nino, periodId.value)
       )
     }
   }
 }
 
-case class CreateHistoricNonFhlUkPiePeriodSummaryHateoasData(nino: String, periodId: String, transactionId: String) extends HateoasData
+case class CreateHistoricNonFhlUkPiePeriodSummaryHateoasData(nino: String, periodId: PeriodId) extends HateoasData

--- a/test/v2/connectors/CreateHistoricFhlUkPiePeriodSummaryConnectorSpec.scala
+++ b/test/v2/connectors/CreateHistoricFhlUkPiePeriodSummaryConnectorSpec.scala
@@ -27,16 +27,14 @@ import v2.models.request.createHistoricFhlUkPiePeriodSummary.{
   CreateHistoricFhlUkPiePeriodSummaryRequest,
   CreateHistoricFhlUkPiePeriodSummaryRequestBody
 }
-import v2.models.response.createHistoricFhlUkPiePeriodSummary.CreateHistoricFhlUkPiePeriodSummaryResponse
 
 import scala.concurrent.Future
 
 class CreateHistoricFhlUkPiePeriodSummaryConnectorSpec extends ConnectorSpec {
 
-  val transactionRef = "some-transaction-reference"
-  val nino           = "WE123567A"
-  val fromDate       = "2021-01-06"
-  val toDate         = "2021-02-06"
+  val nino     = "WE123567A"
+  val fromDate = "2021-01-06"
+  val toDate   = "2021-02-06"
 
   val income: UkFhlPieIncome = UkFhlPieIncome(Some(129.10), Some(129.11), Some(UkPropertyIncomeRentARoom(Some(144.23))))
 
@@ -67,8 +65,6 @@ class CreateHistoricFhlUkPiePeriodSummaryConnectorSpec extends ConnectorSpec {
 
   val consolidatedRequestData: CreateHistoricFhlUkPiePeriodSummaryRequest = CreateHistoricFhlUkPiePeriodSummaryRequest(Nino(nino), consolidatedBody)
 
-  val downstreamResponseData = CreateHistoricFhlUkPiePeriodSummaryResponse(transactionRef, None)
-
   class Test extends MockHttpClient with MockAppConfig {
 
     val connector: CreateHistoricFhlUkPiePeriodSummaryConnector = new CreateHistoricFhlUkPiePeriodSummaryConnector(
@@ -85,7 +81,7 @@ class CreateHistoricFhlUkPiePeriodSummaryConnectorSpec extends ConnectorSpec {
   "connector" must {
 
     "post a body with dates, income and expenses and return a 202 with the Period ID added" in new Test {
-      val downstreamOutcome = Right(ResponseWrapper(transactionRef, downstreamResponseData))
+      val downstreamOutcome = Right(ResponseWrapper(correlationId, ()))
 
       implicit val hc: HeaderCarrier                    = HeaderCarrier(otherHeaders = otherHeaders ++ Seq("Content-Type" -> "application/json"))
       val requiredIfsHeadersPost: Seq[(String, String)] = requiredIfsHeaders ++ Seq("Content-Type" -> "application/json")
@@ -105,7 +101,7 @@ class CreateHistoricFhlUkPiePeriodSummaryConnectorSpec extends ConnectorSpec {
     }
 
     "post a body with dates, income and consolidated expenses and return a 202 with the Period ID added" in new Test {
-      val downstreamOutcome = Right(ResponseWrapper(transactionRef, downstreamResponseData))
+      val downstreamOutcome = Right(ResponseWrapper(correlationId, ()))
 
       implicit val hc: HeaderCarrier                    = HeaderCarrier(otherHeaders = otherHeaders ++ Seq("Content-Type" -> "application/json"))
       val requiredIfsHeadersPost: Seq[(String, String)] = requiredIfsHeaders ++ Seq("Content-Type" -> "application/json")

--- a/test/v2/connectors/CreateHistoricNonFhlUkPropertyPeriodSummaryConnectorSpec.scala
+++ b/test/v2/connectors/CreateHistoricNonFhlUkPropertyPeriodSummaryConnectorSpec.scala
@@ -21,18 +21,16 @@ import uk.gov.hmrc.http.HeaderCarrier
 import v2.mocks.MockHttpClient
 import v2.models.domain.Nino
 import v2.models.outcomes.ResponseWrapper
-import v2.models.request.common.ukPropertyRentARoom.{ UkPropertyExpensesRentARoom, UkPropertyIncomeRentARoom }
+import v2.models.request.common.ukPropertyRentARoom.{UkPropertyExpensesRentARoom, UkPropertyIncomeRentARoom}
 import v2.models.request.createHistoricNonFhlUkPropertyPeriodSummary._
-import v2.models.response.createHistoricNonFhlUkPiePeriodSummary.CreateHistoricNonFhlUkPiePeriodSummaryResponse
 
 import scala.concurrent.Future
 
 class CreateHistoricNonFhlUkPropertyPeriodSummaryConnectorSpec extends ConnectorSpec {
 
-  val transactionReference: String = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
-  val nino: String                 = "TC663795B"
-  val fromDate                     = "2021-01-06"
-  val toDate                       = "2021-02-06"
+  val nino: String = "TC663795B"
+  val fromDate     = "2021-01-06"
+  val toDate       = "2021-02-06"
 
   val income: UkNonFhlPropertyIncome =
     UkNonFhlPropertyIncome(Some(2355.45), Some(454.56), Some(123.45), Some(234.53), Some(567.89), Some(UkPropertyIncomeRentARoom(Some(567.56))))
@@ -82,8 +80,6 @@ class CreateHistoricNonFhlUkPropertyPeriodSummaryConnectorSpec extends Connector
   val consolidatedRequestData: CreateHistoricNonFhlUkPropertyPeriodSummaryRequest =
     CreateHistoricNonFhlUkPropertyPeriodSummaryRequest(Nino(nino), consolidatedRequestBody)
 
-  val responseData: CreateHistoricNonFhlUkPiePeriodSummaryResponse = CreateHistoricNonFhlUkPiePeriodSummaryResponse(transactionReference, None)
-
   class Test extends MockHttpClient with MockAppConfig {
 
     val connector: CreateHistoricNonFhlUkPropertyPeriodSummaryConnector = new CreateHistoricNonFhlUkPropertyPeriodSummaryConnector(
@@ -100,7 +96,7 @@ class CreateHistoricNonFhlUkPropertyPeriodSummaryConnectorSpec extends Connector
   "connector" must {
 
     "post a body with dates, income and expenses and return a 202 with the Period ID added" in new Test {
-      val downstreamOutcome = Right(ResponseWrapper(transactionReference, responseData))
+      val downstreamOutcome = Right(ResponseWrapper(correlationId, ()))
 
       implicit val hc: HeaderCarrier                    = HeaderCarrier(otherHeaders = otherHeaders ++ Seq("Content-Type" -> "application/json"))
       val requiredIfsHeadersPost: Seq[(String, String)] = requiredIfsHeaders ++ Seq("Content-Type" -> "application/json")
@@ -120,7 +116,7 @@ class CreateHistoricNonFhlUkPropertyPeriodSummaryConnectorSpec extends Connector
     }
 
     "post a body with dates, income and consolidated expenses and return a 202 with the Period ID added" in new Test {
-      val downstreamOutcome = Right(ResponseWrapper(transactionReference, responseData))
+      val downstreamOutcome = Right(ResponseWrapper(correlationId, ()))
 
       implicit val hc: HeaderCarrier                    = HeaderCarrier(otherHeaders = otherHeaders ++ Seq("Content-Type" -> "application/json"))
       val requiredIfsHeadersPost: Seq[(String, String)] = requiredIfsHeaders ++ Seq("Content-Type" -> "application/json")

--- a/test/v2/controllers/CreateHistoricFhlUkPiePeriodSummaryControllerSpec.scala
+++ b/test/v2/controllers/CreateHistoricFhlUkPiePeriodSummaryControllerSpec.scala
@@ -23,9 +23,9 @@ import v2.mocks.MockIdGenerator
 import v2.mocks.hateoas.MockHateoasFactory
 import v2.mocks.requestParsers.MockCreateHistoricFhlUkPiePeriodSummaryRequestParser
 import v2.mocks.services.{ MockCreateHistoricFhlUkPiePeriodSummaryService, MockEnrolmentsAuthService, MockMtdIdLookupService }
-import v2.models.domain.Nino
-import v2.models.hateoas.{ HateoasWrapper, Link }
+import v2.models.domain.{ Nino, PeriodId }
 import v2.models.hateoas.Method.GET
+import v2.models.hateoas.{ HateoasWrapper, Link }
 import v2.models.outcomes.ResponseWrapper
 import v2.models.request.createHistoricFhlUkPiePeriodSummary.{
   CreateHistoricFhlUkPiePeriodSummaryRawData,
@@ -49,10 +49,9 @@ class CreateHistoricFhlUkPiePeriodSummaryControllerSpec
     with MockHateoasFactory
     with MockIdGenerator {
 
-  private val nino: String                 = "AA123456A"
-  private val correlationId: String        = "a1e8057e-fbbc-47a8-a8b4-78d9f015c253"
-  private val transactionReference: String = "transaction-reference"
-  private val periodId: String             = "2021-01-01_2021-01-02"
+  private val nino: String          = "AA123456A"
+  private val correlationId: String = "a1e8057e-fbbc-47a8-a8b4-78d9f015c253"
+  private val periodId              = "2021-01-01_2021-01-02"
 
   trait Test {
     val hc: HeaderCarrier = HeaderCarrier()
@@ -96,7 +95,7 @@ class CreateHistoricFhlUkPiePeriodSummaryControllerSpec
          |}
          |""".stripMargin)
 
-    private val response: CreateHistoricFhlUkPiePeriodSummaryResponse = CreateHistoricFhlUkPiePeriodSummaryResponse(transactionReference, None)
+    private val response: CreateHistoricFhlUkPiePeriodSummaryResponse = CreateHistoricFhlUkPiePeriodSummaryResponse(PeriodId(periodId))
 
     "Create" should {
       "return a successful response " when {
@@ -112,7 +111,7 @@ class CreateHistoricFhlUkPiePeriodSummaryControllerSpec
             )
 
           MockHateoasFactory
-            .wrap(response, CreateHistoricFhlUkPiePeriodSummaryHateoasData(nino, periodId, transactionReference))
+            .wrap(response, CreateHistoricFhlUkPiePeriodSummaryHateoasData(nino, PeriodId(periodId)))
             .returns(HateoasWrapper(response, hateoasLinks))
 
           val result: Future[Result] = controller.handleRequest(nino)(fakeRequestWithBody(requestBodyJson))

--- a/test/v2/controllers/CreateHistoricNonFhlUkPiePeriodSummaryControllerSpec.scala
+++ b/test/v2/controllers/CreateHistoricNonFhlUkPiePeriodSummaryControllerSpec.scala
@@ -23,7 +23,7 @@ import v2.mocks.MockIdGenerator
 import v2.mocks.hateoas.MockHateoasFactory
 import v2.mocks.requestParsers.MockCreateHistoricNonFhlUkPiePeriodSummaryRequestParser
 import v2.mocks.services.{ MockCreateHistoricNonFhlUkPiePeriodSummaryService, MockEnrolmentsAuthService, MockMtdIdLookupService }
-import v2.models.domain.Nino
+import v2.models.domain.{ Nino, PeriodId }
 import v2.models.errors._
 import v2.models.hateoas.HateoasWrapper
 import v2.models.outcomes.ResponseWrapper
@@ -51,7 +51,6 @@ class CreateHistoricNonFhlUkPiePeriodSummaryControllerSpec
 
   private val nino          = "AA123456A"
   private val periodId      = "2019-03-11_2020-04-23"
-  private val transactionId = "0000000000000001"
   private val correlationId = "a1e8057e-fbbc-47a8-a8b4-78d9f015c253"
 
   trait Test {
@@ -100,7 +99,7 @@ class CreateHistoricNonFhlUkPiePeriodSummaryControllerSpec
     """.stripMargin
   )
 
-  private val response = CreateHistoricNonFhlUkPiePeriodSummaryResponse(transactionId, Some(periodId))
+  private val response = CreateHistoricNonFhlUkPiePeriodSummaryResponse(PeriodId(periodId))
 
   "create" should {
     "return a successful response" when {
@@ -114,7 +113,7 @@ class CreateHistoricNonFhlUkPiePeriodSummaryControllerSpec
           .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
 
         MockHateoasFactory
-          .wrap(response, CreateHistoricNonFhlUkPiePeriodSummaryHateoasData(nino, periodId, transactionId))
+          .wrap(response, CreateHistoricNonFhlUkPiePeriodSummaryHateoasData(nino, PeriodId(periodId)))
           .returns(HateoasWrapper(response, testHateoasLinks))
 
         val result: Future[Result] = controller.handleRequest(nino)(fakeRequestWithBody(requestBodyJson))

--- a/test/v2/mocks/connectors/MockCreateHistoricFhlUkPiePeriodSummaryConnector.scala
+++ b/test/v2/mocks/connectors/MockCreateHistoricFhlUkPiePeriodSummaryConnector.scala
@@ -19,11 +19,10 @@ package v2.mocks.connectors
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.http.HeaderCarrier
-import v2.connectors.{CreateHistoricFhlUkPiePeriodSummaryConnector, DownstreamOutcome}
+import v2.connectors.{ CreateHistoricFhlUkPiePeriodSummaryConnector, DownstreamOutcome }
 import v2.models.request.createHistoricFhlUkPiePeriodSummary.CreateHistoricFhlUkPiePeriodSummaryRequest
-import v2.models.response.createHistoricFhlUkPiePeriodSummary.CreateHistoricFhlUkPiePeriodSummaryResponse
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 trait MockCreateHistoricFhlUkPiePeriodSummaryConnector extends MockFactory {
 
@@ -31,10 +30,15 @@ trait MockCreateHistoricFhlUkPiePeriodSummaryConnector extends MockFactory {
 
   object MockCreateHistoricFhlUkPiePeriodSummaryConnector {
 
-    def createPropertyPeriodSummary(requestData: CreateHistoricFhlUkPiePeriodSummaryRequest):
-    CallHandler[Future[DownstreamOutcome[CreateHistoricFhlUkPiePeriodSummaryResponse]]] = {
-      (mockCreateHistoricFhlUkPiePropertyConnector
-        .createPeriodSummary(_:  CreateHistoricFhlUkPiePeriodSummaryRequest)(_: HeaderCarrier, _: ExecutionContext, _: String))
+    def createPropertyPeriodSummary(requestData: CreateHistoricFhlUkPiePeriodSummaryRequest): CallHandler[Future[DownstreamOutcome[Unit]]] = {
+      (
+        mockCreateHistoricFhlUkPiePropertyConnector
+          .createPeriodSummary(_: CreateHistoricFhlUkPiePeriodSummaryRequest)(
+            _: HeaderCarrier,
+            _: ExecutionContext,
+            _: String
+          )
+        )
         .expects(requestData, *, *, *)
     }
   }

--- a/test/v2/mocks/connectors/MockCreateHistoricNonFhlUkPropertyPeriodSummaryConnector.scala
+++ b/test/v2/mocks/connectors/MockCreateHistoricNonFhlUkPropertyPeriodSummaryConnector.scala
@@ -19,11 +19,10 @@ package v2.mocks.connectors
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.http.HeaderCarrier
-import v2.connectors.{ CreateHistoricNonFhlUkPropertyPeriodSummaryConnector, DownstreamOutcome }
+import v2.connectors.{CreateHistoricNonFhlUkPropertyPeriodSummaryConnector, DownstreamOutcome}
 import v2.models.request.createHistoricNonFhlUkPropertyPeriodSummary.CreateHistoricNonFhlUkPropertyPeriodSummaryRequest
-import v2.models.response.createHistoricNonFhlUkPiePeriodSummary.CreateHistoricNonFhlUkPiePeriodSummaryResponse
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 trait MockCreateHistoricNonFhlUkPropertyPeriodSummaryConnector extends MockFactory {
 
@@ -32,8 +31,8 @@ trait MockCreateHistoricNonFhlUkPropertyPeriodSummaryConnector extends MockFacto
 
   object MockCreateHistoricNonFhlUkPropertyPeriodSummaryConnector {
 
-    def createHistoricNonFhlUkProperty(requestData: CreateHistoricNonFhlUkPropertyPeriodSummaryRequest)
-      : CallHandler[Future[DownstreamOutcome[CreateHistoricNonFhlUkPiePeriodSummaryResponse]]] = {
+    def createHistoricNonFhlUkProperty(
+        requestData: CreateHistoricNonFhlUkPropertyPeriodSummaryRequest): CallHandler[Future[DownstreamOutcome[Unit]]] = {
       (
         mockCreateHistoricNonFhlUkPropertyPeriodSummaryConnector
           .createPeriodSummary(_: CreateHistoricNonFhlUkPropertyPeriodSummaryRequest)(

--- a/test/v2/models/domain/PeriodIdSpec.scala
+++ b/test/v2/models/domain/PeriodIdSpec.scala
@@ -16,6 +16,7 @@
 
 package v2.models.domain
 
+import play.api.libs.json.{ JsString, Json }
 import support.UnitSpec
 
 class PeriodIdSpec extends UnitSpec {
@@ -39,6 +40,13 @@ class PeriodIdSpec extends UnitSpec {
       "create a valid PeriodId" in {
         val result = PeriodId(from = "2017-04-06", to = "2017-07-04")
         result.value shouldBe "2017-04-06_2017-07-04"
+      }
+    }
+
+    "serialized to JSON" must {
+      "serialize the embedded value as a string" in {
+        val value = "2017-04-06_2017-07-04"
+        Json.toJson(PeriodId(value)) shouldBe JsString(value)
       }
     }
   }

--- a/test/v2/models/response/createHistoricFhlUkPiePeriodSummary/CreateHistoricFhlUkPiePeriodSummaryResponseSpec.scala
+++ b/test/v2/models/response/createHistoricFhlUkPiePeriodSummary/CreateHistoricFhlUkPiePeriodSummaryResponseSpec.scala
@@ -16,19 +16,13 @@
 
 package v2.models.response.createHistoricFhlUkPiePeriodSummary
 
-import play.api.libs.json.{ JsValue, Json }
+import play.api.libs.json.{JsValue, Json}
 import support.UnitSpec
+import v2.models.domain.PeriodId
 
 class CreateHistoricFhlUkPiePeriodSummaryResponseSpec extends UnitSpec {
 
-  val transactionRef: String = "v2509e91f-2689-453e-9ddc-7e3cf97a8e41"
-  val periodId: String       = "2017-04-06_2017-07-05"
-
-  val jsonFromDownstream: JsValue = Json.parse(s"""
-      | {
-      |     "transactionReference": "$transactionRef"
-      | }
-      """.stripMargin)
+  val periodId: String = "2017-04-06_2017-07-05"
 
   val expectedJsontoVendor: JsValue = Json.parse(s"""
        | {
@@ -36,20 +30,10 @@ class CreateHistoricFhlUkPiePeriodSummaryResponseSpec extends UnitSpec {
        | }
        """.stripMargin)
 
-  "reads" when {
-    "passed valid JSON" should {
-      "return a valid object" in {
-        val expected = CreateHistoricFhlUkPiePeriodSummaryResponse(transactionRef, None)
-        val result   = jsonFromDownstream.as[CreateHistoricFhlUkPiePeriodSummaryResponse]
-        result shouldBe expected
-      }
-    }
-  }
-
   "writes" when {
     "passed an object" should {
       "return the object as JSON" in {
-        val response = CreateHistoricFhlUkPiePeriodSummaryResponse(transactionRef, Some(periodId))
+        val response = CreateHistoricFhlUkPiePeriodSummaryResponse(PeriodId(periodId))
         val result   = Json.toJson(response)
         result shouldBe expectedJsontoVendor
       }

--- a/test/v2/models/response/createHistoricNonFhlUkPiePeriodSummary/CreateHistoricNonFhlUkPiePeriodSummaryResponseSpec.scala
+++ b/test/v2/models/response/createHistoricNonFhlUkPiePeriodSummary/CreateHistoricNonFhlUkPiePeriodSummaryResponseSpec.scala
@@ -18,40 +18,24 @@ package v2.models.response.createHistoricNonFhlUkPiePeriodSummary
 
 import play.api.libs.json.{ JsValue, Json }
 import support.UnitSpec
+import v2.models.domain.PeriodId
 
 class CreateHistoricNonFhlUkPiePeriodSummaryResponseSpec extends UnitSpec {
 
-  val transactionRef: String = "v2509e91f-2689-453e-9ddc-7e3cf97a8e41"
-  val periodId: String       = "2017-04-06_2017-07-05"
+  val periodId: String = "2017-04-06_2017-07-05"
 
-  val jsonFromDownstream: JsValue = Json.parse(s"""
-                                                  | {
-                                                  |     "transactionReference": "$transactionRef"
-                                                  | }
-      """.stripMargin)
-
-  val expectedJsontoVendor: JsValue = Json.parse(s"""
+  val expectedJsonToVendor: JsValue = Json.parse(s"""
                                                     | {
                                                     |    "periodId": "$periodId"
                                                     | }
        """.stripMargin)
 
-  "reads" when {
-    "passed valid JSON" should {
-      "return a valid object" in {
-        val expected = CreateHistoricNonFhlUkPiePeriodSummaryResponse(transactionRef, None)
-        val result   = jsonFromDownstream.as[CreateHistoricNonFhlUkPiePeriodSummaryResponse]
-        result shouldBe expected
-      }
-    }
-  }
-
   "writes" when {
     "passed an object" should {
       "return the object as JSON" in {
-        val response = CreateHistoricNonFhlUkPiePeriodSummaryResponse(transactionRef, Some(periodId))
+        val response = CreateHistoricNonFhlUkPiePeriodSummaryResponse(PeriodId(periodId))
         val result   = Json.toJson(response)
-        result shouldBe expectedJsontoVendor
+        result shouldBe expectedJsonToVendor
       }
     }
   }

--- a/test/v2/services/CreateHistoricFhlUkPiePeriodSummaryServiceSpec.scala
+++ b/test/v2/services/CreateHistoricFhlUkPiePeriodSummaryServiceSpec.scala
@@ -19,7 +19,7 @@ package v2.services
 import uk.gov.hmrc.http.HeaderCarrier
 import v2.controllers.EndpointLogContext
 import v2.mocks.connectors.MockCreateHistoricFhlUkPiePeriodSummaryConnector
-import v2.models.domain.Nino
+import v2.models.domain.{ Nino, PeriodId }
 import v2.models.errors.{ ErrorWrapper, _ }
 import v2.models.outcomes.ResponseWrapper
 import v2.models.request.common.ukFhlPieProperty.{ UkFhlPieExpenses, UkFhlPieIncome }
@@ -34,7 +34,7 @@ import scala.concurrent.Future
 
 class CreateHistoricFhlUkPiePeriodSummaryServiceSpec extends ServiceSpec {
 
-  implicit val transactionReference: String = "some-transaction-reference"
+  implicit val correlationId: String = "some-correlation-id"
 
   val nino     = "WE123567A"
   val fromDate = "2021-01-06"
@@ -66,8 +66,8 @@ class CreateHistoricFhlUkPiePeriodSummaryServiceSpec extends ServiceSpec {
   val requestData: CreateHistoricFhlUkPiePeriodSummaryRequest             = CreateHistoricFhlUkPiePeriodSummaryRequest(Nino(nino), requestBody)
   val consolidatedRequestData: CreateHistoricFhlUkPiePeriodSummaryRequest = CreateHistoricFhlUkPiePeriodSummaryRequest(Nino(nino), consolidatedBody)
 
-  val responseDataWithPeriodIdAdded: CreateHistoricFhlUkPiePeriodSummaryResponse =
-    CreateHistoricFhlUkPiePeriodSummaryResponse(transactionReference, Some(periodId))
+  val responseData: CreateHistoricFhlUkPiePeriodSummaryResponse =
+    CreateHistoricFhlUkPiePeriodSummaryResponse(PeriodId(periodId))
 
   trait Test extends MockCreateHistoricFhlUkPiePeriodSummaryConnector {
     implicit val hc: HeaderCarrier              = HeaderCarrier()
@@ -83,19 +83,19 @@ class CreateHistoricFhlUkPiePeriodSummaryServiceSpec extends ServiceSpec {
       "return mapped result for regular period summary" in new Test {
         MockCreateHistoricFhlUkPiePeriodSummaryConnector
           .createPropertyPeriodSummary(requestData)
-          .returns(Future.successful(Right(ResponseWrapper(transactionReference, responseDataWithPeriodIdAdded))))
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
 
         val result = await(service.createPeriodSummary(requestData))
-        result shouldBe Right(ResponseWrapper(transactionReference, responseDataWithPeriodIdAdded))
+        result shouldBe Right(ResponseWrapper(correlationId, responseData))
       }
 
       "return mapped result for consolidated expenses period summary" in new Test {
         MockCreateHistoricFhlUkPiePeriodSummaryConnector
           .createPropertyPeriodSummary(consolidatedRequestData)
-          .returns(Future.successful(Right(ResponseWrapper(transactionReference, responseDataWithPeriodIdAdded))))
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
 
         val result = await(service.createPeriodSummary(consolidatedRequestData))
-        result shouldBe Right(ResponseWrapper(transactionReference, responseDataWithPeriodIdAdded))
+        result shouldBe Right(ResponseWrapper(correlationId, responseData))
 
       }
     }
@@ -105,9 +105,9 @@ class CreateHistoricFhlUkPiePeriodSummaryServiceSpec extends ServiceSpec {
         s" return a$ifsErrorCode from the service" in new Test {
           MockCreateHistoricFhlUkPiePeriodSummaryConnector
             .createPropertyPeriodSummary(requestData)
-            .returns(Future.successful(Left(ResponseWrapper(transactionReference, DownstreamErrors.single(DownstreamErrorCode(ifsErrorCode))))))
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(ifsErrorCode))))))
 
-          await(service.createPeriodSummary(requestData)) shouldBe Left(ErrorWrapper(transactionReference, error))
+          await(service.createPeriodSummary(requestData)) shouldBe Left(ErrorWrapper(correlationId, error))
         }
 
       val input = Seq(


### PR DESCRIPTION
Simplify CreateHistoricFhlUkPiePeriodSummaryResponse and CreateHistoricNonFhlUkPiePeriodSummaryResponse, which contained transactionReference and an optional periodId, neither of which were being used.

These now contain a PeriodId which can be used directly and the connector returns a unit result (ignoring the transactionReference).