### PR TITLE
Fix some hateoas links

### DIFF
--- a/app/v2/hateoas/HateoasLinks.scala
+++ b/app/v2/hateoas/HateoasLinks.scala
@@ -122,11 +122,11 @@ trait HateoasLinks {
   }
 
   def createAmendHistoricFhlUkPropertyAnnualSubmission(appConfig: AppConfig, nino: String, taxYear: String): Link = {
-    Link(href = ukHistoricFhlAnnualUri(appConfig, nino, taxYear), method = PUT, rel = "create-and-amend-historic-fhl-uk-property-annual-submission")
+    Link(href = ukHistoricFhlAnnualUri(appConfig, nino, taxYear), method = PUT, rel = "create-and-amend-uk-property-historic-fhl-annual-submission")
   }
 
   def deleteHistoricFhlUkPropertyAnnualSubmission(appConfig: AppConfig, nino: String, taxYear: String): Link = {
-    Link(href = ukHistoricFhlAnnualUri(appConfig, nino, taxYear), method = DELETE, rel = "delete-historic-fhl-uk-property-annual-submission")
+    Link(href = ukHistoricFhlAnnualUri(appConfig, nino, taxYear), method = DELETE, rel = "delete-uk-property-historic-fhl-annual-submission")
   }
 
   def createAmendHistoricNonFhlUkPropertyAnnualSubmission(appConfig: AppConfig, nino: String, taxYear: String): Link = {

--- a/app/v2/models/response/retrieveHistoricFhlUkPropertyAnnualSubmission/RetrieveHistoricFhlUkPropertyAnnualSubmissionResponse.scala
+++ b/app/v2/models/response/retrieveHistoricFhlUkPropertyAnnualSubmission/RetrieveHistoricFhlUkPropertyAnnualSubmissionResponse.scala
@@ -38,6 +38,8 @@ object RetrieveHistoricFhlUkPropertyAnnualSubmissionResponse extends HateoasLink
       import data._
       Seq(
         retrieveHistoricFhlUkPropertyAnnualSubmission(appConfig, nino, taxYear, self = true),
+        createAmendHistoricFhlUkPropertyAnnualSubmission(appConfig, nino, taxYear),
+        deleteHistoricFhlUkPropertyAnnualSubmission(appConfig, nino, taxYear)
       )
     }
   }

--- a/it/v2/endpoints/CreateAmendHistoricFhlUkPropertyAnnualSubmissionControllerISpec.scala
+++ b/it/v2/endpoints/CreateAmendHistoricFhlUkPropertyAnnualSubmissionControllerISpec.scala
@@ -71,12 +71,12 @@ class CreateAmendHistoricFhlUkPropertyAnnualSubmissionControllerISpec extends V2
          |        {
          |            "href": "/individuals/business/property/uk/annual/furnished-holiday-lettings/TC663795B/2020-21",
          |            "method": "PUT",
-         |            "rel": "create-and-amend-historic-fhl-uk-property-annual-submission"
+         |            "rel": "create-and-amend-uk-property-historic-fhl-annual-submission"
          |        },
          |        {
          |            "href": "/individuals/business/property/uk/annual/furnished-holiday-lettings/TC663795B/2020-21",
          |            "method": "DELETE",
-         |            "rel": "delete-historic-fhl-uk-property-annual-submission"
+         |            "rel": "delete-uk-property-historic-fhl-annual-submission"
          |        }
          |    ]
          |}

--- a/it/v2/endpoints/RetrieveHistoricFhlUkPropertyAnnualSubmissionControllerISpec.scala
+++ b/it/v2/endpoints/RetrieveHistoricFhlUkPropertyAnnualSubmissionControllerISpec.scala
@@ -59,6 +59,16 @@ class RetrieveHistoricFhlUkPropertyAnnualSubmissionControllerISpec extends V2Int
          |         "href": "/individuals/business/property/uk/annual/furnished-holiday-lettings/AA123456A/2020-21",
          |         "method": "GET",
          |         "rel": "self"
+         |      },
+         |      {
+         |         "href": "/individuals/business/property/uk/annual/furnished-holiday-lettings/AA123456A/2020-21",
+         |         "method": "PUT",
+         |         "rel": "create-and-amend-uk-property-historic-fhl-annual-submission"
+         |      },
+         |      {
+         |         "href": "/individuals/business/property/uk/annual/furnished-holiday-lettings/AA123456A/2020-21",
+         |         "method": "DELETE",
+         |         "rel": "delete-uk-property-historic-fhl-annual-submission"
          |      }
          |   ]
          |}

--- a/test/v2/hateoas/HateoasLinksSpec.scala
+++ b/test/v2/hateoas/HateoasLinksSpec.scala
@@ -164,6 +164,66 @@ class HateoasLinksSpec extends UnitSpec with MockAppConfig with HateoasLinks {
       }
     }
 
+    "for a Historic Uk Property Annual Submission" must {
+      "fhl" must {
+        "return the HATEOAS link for retrieve" in new Test {
+          val result: Link = retrieveHistoricFhlUkPropertyAnnualSubmission(mockAppConfig, nino = nino, taxYear = taxYear, true)
+
+          result shouldBe
+            Link("/individuals/business/property/uk/annual/furnished-holiday-lettings/{nino}/{taxYear}", GET, "self")
+        }
+
+        "return the HATEOAS link for create + amend" in new Test {
+          val result: Link = createAmendHistoricFhlUkPropertyAnnualSubmission(mockAppConfig, nino = nino, taxYear = taxYear)
+
+          result shouldBe Link(
+            "/individuals/business/property/uk/annual/furnished-holiday-lettings/{nino}/{taxYear}",
+            PUT,
+            "create-and-amend-uk-property-historic-fhl-annual-submission"
+          )
+        }
+
+        "return the HATEOAS link for delete" in new Test {
+          val result: Link = deleteHistoricFhlUkPropertyAnnualSubmission(mockAppConfig, nino = nino, taxYear = taxYear)
+
+          result shouldBe Link(
+            "/individuals/business/property/uk/annual/furnished-holiday-lettings/{nino}/{taxYear}",
+            DELETE,
+            "delete-uk-property-historic-fhl-annual-submission"
+          )
+        }
+      }
+
+      "non-fhl" must {
+        "return the HATEOAS link for retrieve" in new Test {
+          val result: Link = retrieveHistoricNonFhlUkPropertyAnnualSubmission(mockAppConfig, nino = nino, taxYear = taxYear, true)
+
+          result shouldBe
+            Link("/individuals/business/property/uk/annual/non-furnished-holiday-lettings/{nino}/{taxYear}", GET, "self")
+        }
+
+        "return the HATEOAS link for create + amend" in new Test {
+          val result: Link = createAmendHistoricNonFhlUkPropertyAnnualSubmission(mockAppConfig, nino = nino, taxYear = taxYear)
+
+          result shouldBe Link(
+            "/individuals/business/property/uk/annual/non-furnished-holiday-lettings/{nino}/{taxYear}",
+            PUT,
+            "create-and-amend-uk-property-historic-non-fhl-annual-submission"
+          )
+        }
+
+        "return the HATEOAS link for delete" in new Test {
+          val result: Link = deleteHistoricNonFhlUkPropertyAnnualSubmission(mockAppConfig, nino = nino, taxYear = taxYear)
+
+          result shouldBe Link(
+            "/individuals/business/property/uk/annual/non-furnished-holiday-lettings/{nino}/{taxYear}",
+            DELETE,
+            "delete-uk-property-historic-non-fhl-annual-submission"
+          )
+        }
+      }
+    }
+
     "produce the correct links" when {
       "called" in {
         val data: RetrieveHistoricNonFhlUkPiePeriodSummaryHateoasData = RetrieveHistoricNonFhlUkPiePeriodSummaryHateoasData("myNino", "myPeriodId")


### PR DESCRIPTION
@sean-flynn-HMRC and I noticed a couple of the rel strings in the HATEOAS responses didn't align with the [Glossary](https://confluence.tools.tax.service.gov.uk/display/MTE/HATEOAS+Glossary+-+Property+Business+API+V2.0) and also that one endpoint was missing some links, so we have fixed both of these.

We ran ATs and STs against the changes and both passed.