### PR TITLE
Upgraded dependencies for Property business API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test(),
     retrieveManaged := true,
     update / evictionWarningOptions := EvictionWarningOptions.default.withWarnScalaVersionEviction(warnScalaVersionEviction = false),
-    scalaVersion := "2.12.15",
+    scalaVersion := "2.12.16",
     scalacOptions ++= Seq(
       "-Xfatal-warnings",
       "-Wconf:src=routes/.*:silent"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -20,7 +20,7 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrap_28_version = "5.24.0"
+  val bootstrap_28_version = "7.8.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,10 +19,10 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.7.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")

--- a/test/utils/ErrorHandlerSpec.scala
+++ b/test/utils/ErrorHandlerSpec.scala
@@ -17,7 +17,6 @@
 package utils
 
 import java.time.Instant
-
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration
 import play.api.http.Status
@@ -31,7 +30,7 @@ import uk.gov.hmrc.auth.core.InsufficientEnrolments
 import uk.gov.hmrc.http.{HeaderCarrier, JsValidationException, NotFoundException}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.http.connector.AuditResult.Success
-import uk.gov.hmrc.play.audit.model.DataEvent
+import uk.gov.hmrc.play.audit.model.{DataEvent, TruncationLog}
 import uk.gov.hmrc.play.bootstrap.config.HttpAuditEvent
 import v1.models.errors._
 
@@ -62,7 +61,7 @@ class ErrorHandlerSpec extends UnitSpec with GuiceOneAppPerSuite {
       generatedAt = Instant.now()
     )
 
-    (httpAuditEvent.dataEvent(_: String, _: String, _: RequestHeader, _: Map[String, String])(_: HeaderCarrier)).expects(*, *, *, *, *)
+    (httpAuditEvent.dataEvent(_: String, _: String, _: RequestHeader, _: Map[String, String], _: TruncationLog)(_: HeaderCarrier)).expects(*, *, *, *, *,*)
       .returns(dataEvent)
 
     (auditConnector.sendEvent(_ : DataEvent)(_: HeaderCarrier, _: ExecutionContext)).expects(*, *, *)


### PR DESCRIPTION
Anticipated questions: 

1. Why has the Scala version changed in build.sbt? 

The latest edition of [bootstrap-backend-play](https://catalogue.tax.service.gov.uk/repositories/bootstrap-play#bootstrap-backend-play-28) requires Scala version 2.12.16 as a minimum. 

2. Why has the errorHandlerSpec changed? 

The new version of Scala seems to be stricter about mocking the HttpAuditEvent. So I had explicitly state that the mock includes a "TruncationLog". Otherwise the tests would fail. 

