### PR TITLE
MTDSA-19897 - Property API historic annual tax year validation anomalies

### DIFF
--- a/app/api/models/domain/TaxYear.scala
+++ b/app/api/models/domain/TaxYear.scala
@@ -69,7 +69,7 @@ final case class TaxYear private (private val value: String) {
 
 object TaxYear {
 
-  val tysTaxYear: Int = 2024
+  val tysTaxYear: TaxYear = TaxYear.ending(2024)
 
   val minimumTaxYear = new TaxYear("2018")
 
@@ -134,6 +134,8 @@ object TaxYear {
   }
 
   def today(): LocalDate = LocalDate.now(ZoneOffset.UTC)
+
+  implicit val ordering: Ordering[TaxYear] = Ordering.by(_.year)
 
   implicit val writes: Writes[TaxYear] = implicitly[Writes[String]].contramap(_.asMtd)
 }

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -64,8 +64,8 @@ trait AppConfig {
   def featureSwitches: Configuration
   def endpointsEnabled(version: Version): Boolean
 
-  def minimumTaxV2Foreign: Int
-  def minimumTaxV2Uk: Int
+  def minimumTaxV2Foreign: TaxYear
+  def minimumTaxV2Uk: TaxYear
 
   def minimumTaxYearHistoric: TaxYear
   def maximumTaxYearHistoric: TaxYear
@@ -102,8 +102,8 @@ class AppConfigImpl @Inject() (config: ServicesConfig, configuration: Configurat
   def featureSwitches: Configuration               = configuration.getOptional[Configuration](s"feature-switch").getOrElse(Configuration.empty)
   def endpointsEnabled(version: Version): Boolean  = config.getBoolean(s"api.${version.name}.endpoints.enabled")
 
-  val minimumTaxV2Foreign: Int = config.getInt("minimum-tax-year.version-2.foreign")
-  val minimumTaxV2Uk: Int      = config.getInt("minimum-tax-year.version-2.uk")
+  val minimumTaxV2Foreign: TaxYear = TaxYear.starting(config.getInt("minimum-tax-year.version-2.foreign"))
+  val minimumTaxV2Uk: TaxYear      = TaxYear.starting(config.getInt("minimum-tax-year.version-2.uk"))
 
   val minimumTaxYearHistoric: TaxYear = TaxYear.starting(config.getInt("minimum-tax-year.version-2.historic"))
   val maximumTaxYearHistoric: TaxYear = TaxYear.starting(config.getInt("maximum-tax-year.version-2.historic"))

--- a/app/v2/controllers/validators/AmendForeignPropertyPeriodSummaryValidatorFactory.scala
+++ b/app/v2/controllers/validators/AmendForeignPropertyPeriodSummaryValidatorFactory.scala
@@ -31,7 +31,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class AmendForeignPropertyPeriodSummaryValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minTaxYear = appConfig.minimumTaxV2Foreign + 1
+  private lazy val minTaxYear = appConfig.minimumTaxV2Foreign
 
   private val resolveJson = new ResolveNonEmptyJsonObject[AmendForeignPropertyPeriodSummaryRequestBody]()
 

--- a/app/v2/controllers/validators/AmendUkPropertyAnnualSubmissionValidatorFactory.scala
+++ b/app/v2/controllers/validators/AmendUkPropertyAnnualSubmissionValidatorFactory.scala
@@ -31,7 +31,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class AmendUkPropertyAnnualSubmissionValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Uk + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Uk
 
   private val resolveJson = new ResolveNonEmptyJsonObject[AmendUkPropertyAnnualSubmissionRequestBody]()
 

--- a/app/v2/controllers/validators/AmendUkPropertyPeriodSummaryValidatorFactory.scala
+++ b/app/v2/controllers/validators/AmendUkPropertyPeriodSummaryValidatorFactory.scala
@@ -33,7 +33,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class AmendUkPropertyPeriodSummaryValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minTaxYear = appConfig.minimumTaxV2Uk + 1
+  private lazy val minTaxYear = appConfig.minimumTaxV2Uk
 
   private val resolveJson = new ResolveNonEmptyJsonObject[AmendUkPropertyPeriodSummaryRequestBody]()
 

--- a/app/v2/controllers/validators/CreateAmendForeignPropertyAnnualSubmissionValidatorFactory.scala
+++ b/app/v2/controllers/validators/CreateAmendForeignPropertyAnnualSubmissionValidatorFactory.scala
@@ -31,7 +31,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class CreateAmendForeignPropertyAnnualSubmissionValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign
 
   private val resolveJson = new ResolveNonEmptyJsonObject[CreateAmendForeignPropertyAnnualSubmissionRequestBody]
 

--- a/app/v2/controllers/validators/CreateAmendHistoricFhlUkPropertyAnnualSubmissionValidatorFactory.scala
+++ b/app/v2/controllers/validators/CreateAmendHistoricFhlUkPropertyAnnualSubmissionValidatorFactory.scala
@@ -32,8 +32,8 @@ import scala.annotation.nowarn
 @Singleton
 class CreateAmendHistoricFhlUkPropertyAnnualSubmissionValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear =  appConfig.minimumTaxYearHistoric.startYear + 1
-  private lazy val maximumTaxYear = appConfig.maximumTaxYearHistoric.startYear
+  private lazy val minimumTaxYear = appConfig.minimumTaxYearHistoric
+  private lazy val maximumTaxYear = appConfig.maximumTaxYearHistoric
 
   @nowarn("cat=lint-byname-implicit")
   private val resolveJson = new ResolveNonEmptyJsonObject[CreateAmendHistoricFhlUkPropertyAnnualSubmissionRequestBody]()

--- a/app/v2/controllers/validators/CreateAmendHistoricNonFhlUkPropertyAnnualSubmissionValidatorFactory.scala
+++ b/app/v2/controllers/validators/CreateAmendHistoricNonFhlUkPropertyAnnualSubmissionValidatorFactory.scala
@@ -24,20 +24,15 @@ import cats.data.Validated.Valid
 import cats.implicits.{catsSyntaxTuple3Semigroupal, toTraverseOps}
 import config.AppConfig
 import play.api.libs.json.JsValue
-import v2.models.request.createAmendHistoricNonFhlUkPropertyAnnualSubmission.{
-  CreateAmendHistoricNonFhlUkPropertyAnnualSubmissionRequestBody,
-  CreateAmendHistoricNonFhlUkPropertyAnnualSubmissionRequestData,
-  HistoricNonFhlAnnualAdjustments,
-  HistoricNonFhlAnnualAllowances
-}
+import v2.models.request.createAmendHistoricNonFhlUkPropertyAnnualSubmission.{CreateAmendHistoricNonFhlUkPropertyAnnualSubmissionRequestBody, CreateAmendHistoricNonFhlUkPropertyAnnualSubmissionRequestData, HistoricNonFhlAnnualAdjustments, HistoricNonFhlAnnualAllowances}
 
 import javax.inject.{Inject, Singleton}
 
 @Singleton
 class CreateAmendHistoricNonFhlUkPropertyAnnualSubmissionValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxYearHistoric.startYear + 1
-  private lazy val maximumTaxYear = appConfig.maximumTaxYearHistoric.startYear
+  private lazy val minimumTaxYear = appConfig.minimumTaxYearHistoric
+  private lazy val maximumTaxYear = appConfig.maximumTaxYearHistoric
 
   private val resolveJson = new ResolveNonEmptyJsonObject[CreateAmendHistoricNonFhlUkPropertyAnnualSubmissionRequestBody]()
 

--- a/app/v2/controllers/validators/CreateForeignPropertyPeriodSummaryValidatorFactory.scala
+++ b/app/v2/controllers/validators/CreateForeignPropertyPeriodSummaryValidatorFactory.scala
@@ -24,17 +24,14 @@ import cats.implicits._
 import config.AppConfig
 import play.api.libs.json.JsValue
 import v2.controllers.validators.CreateForeignPropertyPeriodSummaryRulesValidator.validateBusinessRules
-import v2.models.request.createForeignPropertyPeriodSummary.{
-  CreateForeignPropertyPeriodSummaryRequestBody,
-  CreateForeignPropertyPeriodSummaryRequestData
-}
+import v2.models.request.createForeignPropertyPeriodSummary.{CreateForeignPropertyPeriodSummaryRequestBody, CreateForeignPropertyPeriodSummaryRequestData}
 
 import javax.inject.{Inject, Singleton}
 
 @Singleton
 class CreateForeignPropertyPeriodSummaryValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign
 
   private val resolveJson = new ResolveNonEmptyJsonObject[CreateForeignPropertyPeriodSummaryRequestBody]()
 

--- a/app/v2/controllers/validators/CreateUkPropertyPeriodSummaryValidatorFactory.scala
+++ b/app/v2/controllers/validators/CreateUkPropertyPeriodSummaryValidatorFactory.scala
@@ -35,7 +35,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class CreateUkPropertyPeriodSummaryValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Uk + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Uk
 
   private val resolveFromAndToDates = new ResolveFromAndToDates(TaxYear.minimumFromDate.year, TaxYear.maximumToDate.year)
 

--- a/app/v2/controllers/validators/DeleteHistoricUkPropertyAnnualSubmissionValidatorFactory.scala
+++ b/app/v2/controllers/validators/DeleteHistoricUkPropertyAnnualSubmissionValidatorFactory.scala
@@ -31,8 +31,8 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class DeleteHistoricUkPropertyAnnualSubmissionValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxHistoric = appConfig.minimumTaxYearHistoric.startYear + 1
-  private lazy val maximumTaxHistoric = appConfig.maximumTaxYearHistoric.startYear
+  private lazy val minimumTaxHistoric = appConfig.minimumTaxYearHistoric
+  private lazy val maximumTaxHistoric = appConfig.maximumTaxYearHistoric
 
   def validator(nino: String, taxYear: String, propertyType: HistoricPropertyType): Validator[DeleteHistoricUkPropertyAnnualSubmissionRequestData] =
     new Validator[DeleteHistoricUkPropertyAnnualSubmissionRequestData] {

--- a/app/v2/controllers/validators/DeletePropertyAnnualSubmissionValidatorFactory.scala
+++ b/app/v2/controllers/validators/DeletePropertyAnnualSubmissionValidatorFactory.scala
@@ -29,7 +29,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class DeletePropertyAnnualSubmissionValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign
 
   def validator(nino: String, businessId: String, taxYear: String): Validator[DeletePropertyAnnualSubmissionRequestData] =
     new Validator[DeletePropertyAnnualSubmissionRequestData] {

--- a/app/v2/controllers/validators/ListPropertyPeriodSummariesValidatorFactory.scala
+++ b/app/v2/controllers/validators/ListPropertyPeriodSummariesValidatorFactory.scala
@@ -29,7 +29,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class ListPropertyPeriodSummariesValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign
 
   def validator(nino: String, businessId: String, taxYear: String): Validator[ListPropertyPeriodSummariesRequestData] =
     new Validator[ListPropertyPeriodSummariesRequestData] {

--- a/app/v2/controllers/validators/RetrieveForeignPropertyAnnualSubmissionValidatorFactory.scala
+++ b/app/v2/controllers/validators/RetrieveForeignPropertyAnnualSubmissionValidatorFactory.scala
@@ -29,7 +29,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class RetrieveForeignPropertyAnnualSubmissionValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign
 
   def validator(nino: String, businessId: String, taxYear: String): Validator[RetrieveForeignPropertyAnnualSubmissionRequestData] =
     new Validator[RetrieveForeignPropertyAnnualSubmissionRequestData] {

--- a/app/v2/controllers/validators/RetrieveForeignPropertyPeriodSummaryValidatorFactory.scala
+++ b/app/v2/controllers/validators/RetrieveForeignPropertyPeriodSummaryValidatorFactory.scala
@@ -29,7 +29,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class RetrieveForeignPropertyPeriodSummaryValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Foreign
 
   def validator(nino: String, businessId: String, taxYear: String, submissionId: String): Validator[RetrieveForeignPropertyPeriodSummaryRequestData] =
     new Validator[RetrieveForeignPropertyPeriodSummaryRequestData] {

--- a/app/v2/controllers/validators/RetrieveHistoricFhlUkPropertyAnnualSubmissionValidatorFactory.scala
+++ b/app/v2/controllers/validators/RetrieveHistoricFhlUkPropertyAnnualSubmissionValidatorFactory.scala
@@ -29,8 +29,8 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class RetrieveHistoricFhlUkPropertyAnnualSubmissionValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxYearHistoric.startYear + 1
-  private lazy val maximumTaxYear = appConfig.maximumTaxYearHistoric.startYear
+  private lazy val minimumTaxYear = appConfig.minimumTaxYearHistoric
+  private lazy val maximumTaxYear = appConfig.maximumTaxYearHistoric
 
   def validator(nino: String, taxYear: String): Validator[RetrieveHistoricFhlUkPropertyAnnualSubmissionRequestData] =
     new Validator[RetrieveHistoricFhlUkPropertyAnnualSubmissionRequestData] {

--- a/app/v2/controllers/validators/RetrieveHistoricNonFhlUkPropertyAnnualSubmissionValidatorFactory.scala
+++ b/app/v2/controllers/validators/RetrieveHistoricNonFhlUkPropertyAnnualSubmissionValidatorFactory.scala
@@ -29,8 +29,8 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class RetrieveHistoricNonFhlUkPropertyAnnualSubmissionValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxHistoric = appConfig.minimumTaxYearHistoric.startYear
-  private lazy val maximumTaxHistoric = appConfig.maximumTaxYearHistoric.startYear
+  private lazy val minimumTaxHistoric = appConfig.minimumTaxYearHistoric
+  private lazy val maximumTaxHistoric = appConfig.maximumTaxYearHistoric
 
   def validator(nino: String, taxYear: String): Validator[RetrieveHistoricNonFhlUkPropertyAnnualSubmissionRequestData] =
     new Validator[RetrieveHistoricNonFhlUkPropertyAnnualSubmissionRequestData] {

--- a/app/v2/controllers/validators/RetrieveUkPropertyAnnualSubmissionValidatorFactory.scala
+++ b/app/v2/controllers/validators/RetrieveUkPropertyAnnualSubmissionValidatorFactory.scala
@@ -29,7 +29,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class RetrieveUkPropertyAnnualSubmissionValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Uk + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Uk
 
   def validator(nino: String, businessId: String, taxYear: String): Validator[RetrieveUkPropertyAnnualSubmissionRequestData] =
     new Validator[RetrieveUkPropertyAnnualSubmissionRequestData] {

--- a/app/v2/controllers/validators/RetrieveUkPropertyPeriodSummaryValidatorFactory.scala
+++ b/app/v2/controllers/validators/RetrieveUkPropertyPeriodSummaryValidatorFactory.scala
@@ -29,7 +29,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class RetrieveUkPropertyPeriodSummaryValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Uk + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Uk
 
   def validator(nino: String, businessId: String, taxYear: String, submissionId: String): Validator[RetrieveUkPropertyPeriodSummaryRequestData] =
     new Validator[RetrieveUkPropertyPeriodSummaryRequestData] {

--- a/app/v3/controllers/validators/CreateUkPropertyPeriodSummaryValidatorFactory.scala
+++ b/app/v3/controllers/validators/CreateUkPropertyPeriodSummaryValidatorFactory.scala
@@ -35,7 +35,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class CreateUkPropertyPeriodSummaryValidatorFactory @Inject() (appConfig: AppConfig) {
 
-  private lazy val minimumTaxYear = appConfig.minimumTaxV2Uk + 1
+  private lazy val minimumTaxYear = appConfig.minimumTaxV2Uk
 
   private val resolveFromAndToDates = new ResolveFromAndToDates(TaxYear.minimumFromDate.year, TaxYear.maximumToDate.year)
 

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -61,8 +61,8 @@ trait MockAppConfig extends MockFactory {
     def confidenceLevelCheckEnabled: CallHandler[ConfidenceLevelConfig] =
       (() => mockAppConfig.confidenceLevelConfig).expects()
 
-    def minimumTaxV2Foreign: CallHandler[Int] = (() => mockAppConfig.minimumTaxV2Foreign).expects()
-    def minimumTaxV2Uk: CallHandler[Int]      = (() => mockAppConfig.minimumTaxV2Uk).expects()
+    def minimumTaxV2Foreign: CallHandler[TaxYear] = (() => mockAppConfig.minimumTaxV2Foreign).expects()
+    def minimumTaxV2Uk: CallHandler[TaxYear]      = (() => mockAppConfig.minimumTaxV2Uk).expects()
 
     def minimumTaxYearHistoric: CallHandler[TaxYear] = (() => mockAppConfig.minimumTaxYearHistoric).expects()
     def maximumTaxYearHistoric: CallHandler[TaxYear] = (() => mockAppConfig.maximumTaxYearHistoric).expects()

--- a/test/v2/controllers/validators/ListPropertyPeriodSummariesValidatorFactorySpec.scala
+++ b/test/v2/controllers/validators/ListPropertyPeriodSummariesValidatorFactorySpec.scala
@@ -27,7 +27,7 @@ class ListPropertyPeriodSummariesValidatorFactorySpec extends UnitSpec with Mock
 
   private val validNino       = "AA123456A"
   private val validBusinessId = "XAIS12345678901"
-  private val validTaxYear    = "2021-22"
+  private val validTaxYear    = "2023-24"
 
   private val parsedNino       = Nino(validNino)
   private val parsedBusinessId = BusinessId(validBusinessId)
@@ -38,7 +38,7 @@ class ListPropertyPeriodSummariesValidatorFactorySpec extends UnitSpec with Mock
   private def validator(nino: String, businessId: String, taxYear: String) =
     validatorFactory.validator(nino, businessId, taxYear)
 
-  MockAppConfig.minimumTaxV2Foreign.returns(2021)
+  MockAppConfig.minimumTaxV2Foreign.returns(TaxYear.starting(2021))
 
   "validator" should {
     "return the parsed domain object" when {
@@ -47,6 +47,12 @@ class ListPropertyPeriodSummariesValidatorFactorySpec extends UnitSpec with Mock
           validator(validNino, validBusinessId, validTaxYear).validateAndWrapResult()
 
         result shouldBe Right(ListPropertyPeriodSummariesRequestData(parsedNino, parsedBusinessId, parsedTaxYear))
+      }
+
+      "passed the minimum supported taxYear" in {
+        val taxYearString = "2021-22"
+        validator(validNino, validBusinessId, taxYearString).validateAndWrapResult() shouldBe
+          Right(ListPropertyPeriodSummariesRequestData(parsedNino, parsedBusinessId, TaxYear.fromMtd(taxYearString)))
       }
     }
 
@@ -72,11 +78,9 @@ class ListPropertyPeriodSummariesValidatorFactorySpec extends UnitSpec with Mock
         result shouldBe Left(ErrorWrapper(correlationId, BusinessIdFormatError))
       }
 
-      "passed an unsupported taxYear" in {
-        val result: Either[ErrorWrapper, ListPropertyPeriodSummariesRequestData] =
-          validator(validNino, validBusinessId, "2020-21").validateAndWrapResult()
-
-        result shouldBe Left(ErrorWrapper(correlationId, RuleTaxYearNotSupportedError))
+      "passed a taxYear immediately before the minimum supported" in {
+        validator(validNino, validBusinessId, "2020-21").validateAndWrapResult() shouldBe
+          Left(ErrorWrapper(correlationId, RuleTaxYearNotSupportedError))
       }
 
       "passed a taxYear spanning an invalid tax year range" in {


### PR DESCRIPTION
- tighten up validator tests for historic annual (as well as non-historic annual and periodic) to ensure we clearly check either side of min and max supported tax years.
- four tests fail as expected
- Use TaxYear in min/max app configs
- Use TaxYear in resolver (otherwise as-is) to prepare for fix
- Fix ResolveTaxYear so all flavours use non-strict minimum consistently
- Apply fixes to validators