### PR TITLE
nojira: Removed zeroEmissionGoodsVehicleAllowance from OAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To view documentation locally ensure the Property Business API is running, and r
 `./run_local_with_dependencies.sh`
 
 Then go to http://localhost:9680/api-documentation/docs/openapi/preview and use this port and version:
-`http://localhost:7798/api/conf/2.0/application.yaml`
+`http://localhost:7798/api/conf/3.0/application.yaml`
 
 ## Changelog
 

--- a/resources/public/api/conf/3.0/schemas/uk_property_period_summary_retrieve/response.json
+++ b/resources/public/api/conf/3.0/schemas/uk_property_period_summary_retrieve/response.json
@@ -228,14 +228,6 @@
               "maximum": 99999999999.99,
               "example": "5000.99"
             },
-            "zeroEmissionGoodsVehicleAllowance": {
-              "description": "The amount of zero emission goods vehicle allowance for goods vehicles purchased for business use. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
-              "type": "number",
-              "multipleOf": 0.01,
-              "minimum": 0.00,
-              "maximum": 99999999999.99,
-              "example": "5000.99"
-            },
             "repairsAndMaintenance": {
               "description": "Property repairs and maintenance. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
               "type": "number",

--- a/resources/public/api/conf/4.0/schemas/uk_property_period_summary_retrieve/response.json
+++ b/resources/public/api/conf/4.0/schemas/uk_property_period_summary_retrieve/response.json
@@ -228,14 +228,6 @@
               "maximum": 99999999999.99,
               "example": "5000.99"
             },
-            "zeroEmissionGoodsVehicleAllowance": {
-              "description": "The amount of zero emission goods vehicle allowance for goods vehicles purchased for business use. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
-              "type": "number",
-              "multipleOf": 0.01,
-              "minimum": 0.00,
-              "maximum": 99999999999.99,
-              "example": "5000.99"
-            },
             "repairsAndMaintenance": {
               "description": "Property repairs and maintenance. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
               "type": "number",


### PR DESCRIPTION
 as it is not part of the ukNonFhlProperty.expenses schema