### PR TITLE
MTDSA-26868 - prepare connectors to allow intent for all methods

### DIFF
--- a/app/api/connectors/BaseDownstreamConnector.scala
+++ b/app/api/connectors/BaseDownstreamConnector.scala
@@ -16,13 +16,11 @@
 
 package api.connectors
 
-import api.connectors.DownstreamUri.{DesUri, IfsUri, TaxYearSpecificIfsUri}
 import config.AppConfig
 import play.api.http.{HeaderNames, MimeTypes}
 import play.api.libs.json.Writes
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads}
-import utils.Logging
-import utils.UrlUtils.appendQueryParams
+import utils.{Logging, UrlUtils}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -30,97 +28,107 @@ trait BaseDownstreamConnector extends Logging {
   val http: HttpClient
   val appConfig: AppConfig
 
-  private val jsonContentTypeHeader = HeaderNames.CONTENT_TYPE -> MimeTypes.JSON
+  // This is to provide an implicit AppConfig in existing connector implementations (which
+  // typically declare the abstract `appConfig` field non-implicitly) without having to change them.
+  implicit protected lazy val _appConfig: AppConfig = appConfig
 
-  def post[Body: Writes, Resp](body: Body, uri: DownstreamUri[Resp])(implicit
+  private val jsonContentTypeHeader = Seq(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+
+  def post[Body: Writes, Resp](body: Body, uri: DownstreamUri[Resp], maybeIntent: Option[String] = None)(implicit
       ec: ExecutionContext,
       hc: HeaderCarrier,
       httpReads: HttpReads[DownstreamOutcome[Resp]],
       correlationId: String): Future[DownstreamOutcome[Resp]] = {
+
+    val strategy = uri.strategy
 
     def doPost(implicit hc: HeaderCarrier): Future[DownstreamOutcome[Resp]] = {
-      http.POST(getBackendUri(uri), body)
+      http.POST(getBackendUri(uri.path, strategy), body)
     }
 
-    doPost(getBackendHeaders(uri, hc, correlationId, jsonContentTypeHeader))
+    for {
+      headers <- getBackendHeaders(strategy, jsonContentTypeHeader ++ intentHeader(maybeIntent))
+      result  <- doPost(headers)
+    } yield result
   }
 
-  def get[Resp](uri: DownstreamUri[Resp], queryParams: Seq[(String, String)] = Nil)(implicit
+  def get[Resp](uri: DownstreamUri[Resp], queryParams: Seq[(String, String)] = Nil, maybeIntent: Option[String] = None)(implicit
       ec: ExecutionContext,
       hc: HeaderCarrier,
       httpReads: HttpReads[DownstreamOutcome[Resp]],
       correlationId: String): Future[DownstreamOutcome[Resp]] = {
 
-    def doGet(implicit hc: HeaderCarrier): Future[DownstreamOutcome[Resp]] = {
-      http.GET(getBackendUri(uri), queryParams)
-    }
+    val strategy = uri.strategy
 
-    doGet(getBackendHeaders(uri, hc, correlationId))
+    def doGet(implicit hc: HeaderCarrier): Future[DownstreamOutcome[Resp]] =
+      http.GET(getBackendUri(uri.path, strategy), queryParams)
+
+    for {
+      headers <- getBackendHeaders(strategy, intentHeader(maybeIntent))
+      result  <- doGet(headers)
+    } yield result
   }
 
-  def put[Body: Writes, Resp](body: Body, uri: DownstreamUri[Resp], intent: Option[String] = None)(implicit
+  def delete[Resp](uri: DownstreamUri[Resp], queryParams: Seq[(String, String)] = Nil, maybeIntent: Option[String] = None)(implicit
       ec: ExecutionContext,
       hc: HeaderCarrier,
       httpReads: HttpReads[DownstreamOutcome[Resp]],
       correlationId: String): Future[DownstreamOutcome[Resp]] = {
 
-    def doPut(implicit hc: HeaderCarrier): Future[DownstreamOutcome[Resp]] = {
-      http.PUT(getBackendUri(uri), body)
-    }
-
-    intent match {
-      case Some(x) => doPut(getBackendHeaders(uri, hc, correlationId, jsonContentTypeHeader, ("intent", x)))
-      case None    => doPut(getBackendHeaders(uri, hc, correlationId, jsonContentTypeHeader))
-    }
-
-  }
-
-  def delete[Resp](uri: DownstreamUri[Resp], queryParams: Seq[(String, String)] = Nil)(implicit
-      ec: ExecutionContext,
-      hc: HeaderCarrier,
-      httpReads: HttpReads[DownstreamOutcome[Resp]],
-      correlationId: String): Future[DownstreamOutcome[Resp]] = {
+    val strategy = uri.strategy
 
     def doDelete(implicit hc: HeaderCarrier): Future[DownstreamOutcome[Resp]] = {
-      // http.DELETE doesn't accept query params (unlike http.GET), so need to construct the query here:
-      val downstreamUri = appendQueryParams(getBackendUri(uri), queryParams)
-      http.DELETE(downstreamUri)
+      val fullUrl = UrlUtils.appendQueryParams(getBackendUri(uri.path, strategy), queryParams)
+      http.DELETE(fullUrl)
     }
 
-    doDelete(getBackendHeaders(uri, hc, correlationId))
+    for {
+      headers <- getBackendHeaders(strategy, intentHeader(maybeIntent))
+      result  <- doDelete(headers)
+    } yield result
   }
 
-  private def getBackendUri[Resp](uri: DownstreamUri[Resp]): String =
-    s"${configFor(uri).baseUrl}/${uri.value}"
+  def put[Body: Writes, Resp](body: Body, uri: DownstreamUri[Resp], maybeIntent: Option[String] = None)(implicit
+      ec: ExecutionContext,
+      hc: HeaderCarrier,
+      httpReads: HttpReads[DownstreamOutcome[Resp]],
+      correlationId: String): Future[DownstreamOutcome[Resp]] = {
 
-  private def getBackendHeaders[Resp](uri: DownstreamUri[Resp],
-                                      hc: HeaderCarrier,
-                                      correlationId: String,
-                                      additionalHeaders: (String, String)*): HeaderCarrier = {
-    val downstreamConfig = configFor(uri)
+    val strategy = uri.strategy
 
-    val passThroughHeaders = hc
-      .headers(downstreamConfig.environmentHeaders.getOrElse(Nil))
-      .filterNot(hdr => additionalHeaders.exists(_._1.equalsIgnoreCase(hdr._1)))
-
-    HeaderCarrier(
-      extraHeaders = hc.extraHeaders ++
-        // Contract headers
-        List(
-          "Authorization" -> s"Bearer ${downstreamConfig.token}",
-          "Environment"   -> downstreamConfig.env,
-          "CorrelationId" -> correlationId
-        ) ++
-        additionalHeaders ++
-        passThroughHeaders
-    )
-  }
-
-  private def configFor[Resp](uri: DownstreamUri[Resp]) =
-    uri match {
-      case DesUri(_)                => appConfig.desDownstreamConfig
-      case IfsUri(_)                => appConfig.ifsDownstreamConfig
-      case TaxYearSpecificIfsUri(_) => appConfig.taxYearSpecificIfsDownstreamConfig
+    def doPut(implicit hc: HeaderCarrier): Future[DownstreamOutcome[Resp]] = {
+      http.PUT(getBackendUri(uri.path, strategy), body)
     }
+
+    for {
+      headers <- getBackendHeaders(strategy, jsonContentTypeHeader ++ intentHeader(maybeIntent))
+      result  <- doPut(headers)
+    } yield result
+  }
+
+  private def intentHeader(maybeIntent: Option[String]) =
+    maybeIntent.map(intent => Seq("intent" -> intent)).getOrElse(Nil)
+
+  private def getBackendUri(path: String, strategy: DownstreamStrategy): String =
+    s"${strategy.baseUrl}/$path"
+
+  private def getBackendHeaders(
+      strategy: DownstreamStrategy,
+      additionalHeaders: Seq[(String, String)]
+  )(implicit ec: ExecutionContext, hc: HeaderCarrier, correlationId: String): Future[HeaderCarrier] = {
+
+    for {
+      contractHeaders <- strategy.contractHeaders(correlationId)
+    } yield {
+      val apiHeaders = hc.extraHeaders ++ contractHeaders ++ additionalHeaders
+
+      val passThroughHeaders = hc
+        .headers(strategy.environmentHeaders)
+        .filterNot(hdr => apiHeaders.exists(_._1.equalsIgnoreCase(hdr._1)))
+
+      HeaderCarrier(extraHeaders = apiHeaders ++ passThroughHeaders)
+    }
+
+  }
 
 }

--- a/app/api/connectors/DownstreamStrategy.scala
+++ b/app/api/connectors/DownstreamStrategy.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.connectors
+
+import com.google.common.base.Charsets
+import config.{BasicAuthDownstreamConfig, DownstreamConfig}
+
+import java.util.Base64
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Represents a strategy for determining necessary HTTP parameters to make a request to a downstream service.
+  */
+trait DownstreamStrategy {
+
+  /** Gets the base HTTP/HTTPS URL for the host
+    */
+  def baseUrl: String
+
+  /** Gets the contract headers that the services require. This includes any Authorization headers, and returns a future to allow for any required
+    * non-blocking retrieval of tokens e.g. from an OAuth service.
+    */
+  def contractHeaders(correlationId: String)(implicit ec: ExecutionContext): Future[Seq[(String, String)]]
+
+  /** Gets the headers in the MTD request that are to be passed through to the downstream service. This includes request tracking headers and
+    * gov-test-scenario headers for when the downstream host is a stub.
+    */
+  def environmentHeaders: Seq[String]
+}
+
+object DownstreamStrategy {
+
+  /** Creates a strategy instance that uses a fixed token for each host/endpoint
+    * @param downstreamConfig
+    *   configuration for the downstream host & endpoint
+    */
+  def standardStrategy(downstreamConfig: DownstreamConfig): DownstreamStrategy = new DownstreamStrategy {
+    override def baseUrl: String = downstreamConfig.baseUrl
+
+    override def contractHeaders(correlationId: String)(implicit ec: ExecutionContext): Future[Seq[(String, String)]] = {
+      Future.successful(
+        List(
+          "Authorization" -> s"Bearer ${downstreamConfig.token}",
+          "Environment"   -> downstreamConfig.env,
+          "CorrelationId" -> correlationId
+        ))
+    }
+
+    override def environmentHeaders: Seq[String] = downstreamConfig.environmentHeaders.getOrElse(Nil)
+  }
+
+  /** Creates a strategy instance that uses the OAuth client id and secret but as a base64-encoded Basic auth token.
+    * @param downstreamConfig
+    *   configuration for the downstream host & endpoint
+    */
+  def basicAuthStrategy(downstreamConfig: BasicAuthDownstreamConfig): DownstreamStrategy = new DownstreamStrategy {
+    override def baseUrl: String = downstreamConfig.baseUrl
+
+    override def contractHeaders(correlationId: String)(implicit ec: ExecutionContext): Future[Seq[(String, String)]] = {
+      val encodedToken = Base64.getEncoder.encodeToString(s"${downstreamConfig.clientId}:${downstreamConfig.clientSecret}".getBytes(Charsets.UTF_8))
+
+      Future.successful(
+        List(
+          "Authorization" -> s"Basic $encodedToken",
+          "Environment"   -> downstreamConfig.env,
+          "CorrelationId" -> correlationId
+        ))
+    }
+
+    override def environmentHeaders: Seq[String] = downstreamConfig.environmentHeaders.getOrElse(Nil)
+  }
+
+}

--- a/app/api/connectors/DownstreamUri.scala
+++ b/app/api/connectors/DownstreamUri.scala
@@ -16,12 +16,28 @@
 
 package api.connectors
 
-sealed trait DownstreamUri[Resp] {
-  val value: String
-}
+import config.{AppConfig, DownstreamConfig}
+
+case class DownstreamUri[+Resp](
+    path: String,
+    strategy: DownstreamStrategy
+)
 
 object DownstreamUri {
-  final case class DesUri[Resp](value: String)                extends DownstreamUri[Resp]
-  final case class IfsUri[Resp](value: String)                extends DownstreamUri[Resp]
-  final case class TaxYearSpecificIfsUri[Resp](value: String) extends DownstreamUri[Resp]
+
+  private def withStandardStrategy[Resp](path: String, config: DownstreamConfig) =
+    DownstreamUri(path, DownstreamStrategy.standardStrategy(config))
+
+  def DesUri[Resp](value: String)(implicit appConfig: AppConfig): DownstreamUri[Resp] =
+    withStandardStrategy(value, appConfig.desDownstreamConfig)
+
+  def IfsUri[Resp](value: String)(implicit appConfig: AppConfig): DownstreamUri[Resp] =
+    withStandardStrategy(value, appConfig.ifsDownstreamConfig)
+
+  def TaxYearSpecificIfsUri[Resp](value: String)(implicit appConfig: AppConfig): DownstreamUri[Resp] =
+    withStandardStrategy(value, appConfig.tysIfsDownstreamConfig)
+
+  def HipUri[Resp](path: String)(implicit appConfig: AppConfig): DownstreamUri[Resp] =
+    DownstreamUri(path, DownstreamStrategy.basicAuthStrategy(appConfig.hipDownstreamConfig))
+
 }

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -35,32 +35,10 @@ trait AppConfig {
   // MTD ID Lookup Config
   def mtdIdBaseUrl: String
 
-  // DES Config
-  def desBaseUrl: String
-  def desEnv: String
-  def desToken: String
-  def desEnvironmentHeaders: Option[Seq[String]]
-
-  lazy val desDownstreamConfig: DownstreamConfig =
-    DownstreamConfig(baseUrl = desBaseUrl, env = desEnv, token = desToken, environmentHeaders = desEnvironmentHeaders)
-
-  // IFS Config
-  def ifsBaseUrl: String
-  def ifsEnv: String
-  def ifsToken: String
-  def ifsEnvironmentHeaders: Option[Seq[String]]
-
-  lazy val ifsDownstreamConfig: DownstreamConfig =
-    DownstreamConfig(baseUrl = ifsBaseUrl, env = ifsEnv, token = ifsToken, environmentHeaders = ifsEnvironmentHeaders)
-
-  // Tax Year Specific (TYS) IFS Config
-  def tysIfsBaseUrl: String
-  def tysIfsEnv: String
-  def tysIfsToken: String
-  def tysIfsEnvironmentHeaders: Option[Seq[String]]
-
-  lazy val taxYearSpecificIfsDownstreamConfig: DownstreamConfig =
-    DownstreamConfig(baseUrl = tysIfsBaseUrl, env = tysIfsEnv, token = tysIfsToken, environmentHeaders = tysIfsEnvironmentHeaders)
+  def desDownstreamConfig: DownstreamConfig
+  def ifsDownstreamConfig: DownstreamConfig
+  def tysIfsDownstreamConfig: DownstreamConfig
+  def hipDownstreamConfig: BasicAuthDownstreamConfig
 
   // API Config
   def apiGatewayContext: String
@@ -99,23 +77,37 @@ class AppConfigImpl @Inject() (config: ServicesConfig, val configuration: Config
   // MTD ID Lookup Config
   val mtdIdBaseUrl: String = config.baseUrl("mtd-id-lookup")
 
-  // DES Config
-  val desBaseUrl: String                         = config.baseUrl("des")
-  val desEnv: String                             = config.getString("microservice.services.des.env")
-  val desToken: String                           = config.getString("microservice.services.des.token")
-  val desEnvironmentHeaders: Option[Seq[String]] = configuration.getOptional[Seq[String]]("microservice.services.des.environmentHeaders")
+  private def serviceKeyFor(serviceName: String) = s"microservice.services.$serviceName"
 
-  // IFS Config
-  val ifsBaseUrl: String                         = config.baseUrl("ifs")
-  val ifsEnv: String                             = config.getString("microservice.services.ifs.env")
-  val ifsToken: String                           = config.getString("microservice.services.ifs.token")
-  val ifsEnvironmentHeaders: Option[Seq[String]] = configuration.getOptional[Seq[String]]("microservice.services.ifs.environmentHeaders")
+  protected def downstreamConfig(serviceName: String): DownstreamConfig = {
+    val baseUrl = config.baseUrl(serviceName)
 
-  // Tax Year Specific (TYS) IFS Config
-  val tysIfsBaseUrl: String                         = config.baseUrl("tys-ifs")
-  val tysIfsEnv: String                             = config.getString("microservice.services.tys-ifs.env")
-  val tysIfsToken: String                           = config.getString("microservice.services.tys-ifs.token")
-  val tysIfsEnvironmentHeaders: Option[Seq[String]] = configuration.getOptional[Seq[String]]("microservice.services.tys-ifs.environmentHeaders")
+    val serviceKey = serviceKeyFor(serviceName)
+
+    val env                = config.getString(s"$serviceKey.env")
+    val token              = config.getString(s"$serviceKey.token")
+    val environmentHeaders = configuration.getOptional[Seq[String]](s"$serviceKey.environmentHeaders")
+
+    DownstreamConfig(baseUrl, env, token, environmentHeaders)
+  }
+
+  protected def basicAuthDownstreamConfig(serviceName: String): BasicAuthDownstreamConfig = {
+    val baseUrl = config.baseUrl(serviceName)
+
+    val serviceKey = serviceKeyFor(serviceName)
+
+    val env                = config.getString(s"$serviceKey.env")
+    val clientId           = config.getString(s"$serviceKey.clientId")
+    val clientSecret       = config.getString(s"$serviceKey.clientSecret")
+    val environmentHeaders = configuration.getOptional[Seq[String]](s"$serviceKey.environmentHeaders")
+
+    BasicAuthDownstreamConfig(baseUrl, env, clientId, clientSecret, environmentHeaders)
+  }
+
+  def desDownstreamConfig: DownstreamConfig          = downstreamConfig("des")
+  def ifsDownstreamConfig: DownstreamConfig          = downstreamConfig("ifs")
+  def tysIfsDownstreamConfig: DownstreamConfig       = downstreamConfig("tys-ifs")
+  def hipDownstreamConfig: BasicAuthDownstreamConfig = basicAuthDownstreamConfig("hip")
 
   // API Config
   val apiGatewayContext: String                    = config.getString("api.gateway.context")

--- a/app/config/DownstreamConfig.scala
+++ b/app/config/DownstreamConfig.scala
@@ -22,3 +22,11 @@ case class DownstreamConfig(
     token: String,
     environmentHeaders: Option[Seq[String]]
 )
+
+case class BasicAuthDownstreamConfig(
+    baseUrl: String,
+    env: String,
+    clientId: String,
+    clientSecret: String,
+    environmentHeaders: Option[Seq[String]]
+)

--- a/app/config/FeatureSwitches.scala
+++ b/app/config/FeatureSwitches.scala
@@ -24,7 +24,7 @@ import javax.inject.Inject
 
 @ImplementedBy(classOf[FeatureSwitchesImpl])
 trait FeatureSwitches {
-  def isPassDeleteIntentEnabled: Boolean
+  def isPassIntentEnabled: Boolean
   def isRuleSubmissionDateErrorEnabled: Boolean
 
   def supportingAgentsAccessControlEnabled: Boolean
@@ -40,7 +40,7 @@ class FeatureSwitchesImpl(featureSwitchConfig: Configuration) extends FeatureSwi
   @Inject
   def this(appConfig: AppConfig) = this(appConfig.featureSwitches)
 
-  val isPassDeleteIntentEnabled: Boolean        = isEnabled("passDeleteIntentHeader")
+  val isPassIntentEnabled: Boolean              = isEnabled("passIntentHeader")
   val isRuleSubmissionDateErrorEnabled: Boolean = isEnabled("ruleSubmissionDateIssue")
 
   val supportingAgentsAccessControlEnabled: Boolean = isEnabled("supporting-agents-access-control")

--- a/app/v2/connectors/DeleteHistoricUkPropertyAnnualSubmissionConnector.scala
+++ b/app/v2/connectors/DeleteHistoricUkPropertyAnnualSubmissionConnector.scala
@@ -40,7 +40,7 @@ class DeleteHistoricUkPropertyAnnualSubmissionConnector @Inject() (val http: Htt
 
     import request._
 
-    val intent = if (featureSwitches.isPassDeleteIntentEnabled) Some("DELETE") else None
+    val intent = if (featureSwitches.isPassIntentEnabled) Some("DELETE") else None
 
     val propertyTypeName = propertyType match {
       case HistoricPropertyType.Fhl    => "furnished-holiday-lettings"

--- a/app/v4/deleteHistoricFhlUkPropertyAnnualSubmission/DeleteHistoricFhlUkPropertyAnnualSubmissionConnector.scala
+++ b/app/v4/deleteHistoricFhlUkPropertyAnnualSubmission/DeleteHistoricFhlUkPropertyAnnualSubmissionConnector.scala
@@ -43,7 +43,7 @@ class DeleteHistoricFhlUkPropertyAnnualSubmissionConnector @Inject() (val http: 
 
     import request._
 
-    val intent = if (featureSwitches.isPassDeleteIntentEnabled) Some("DELETE") else None
+    val intent = if (featureSwitches.isPassIntentEnabled) Some("DELETE") else None
 
     val propertyTypeName = propertyType match {
       case HistoricPropertyType.Fhl    => "furnished-holiday-lettings"

--- a/app/v4/deleteHistoricNonFhlUkPropertyAnnualSubmission/DeleteHistoricNonFhlUkPropertyAnnualSubmissionConnector.scala
+++ b/app/v4/deleteHistoricNonFhlUkPropertyAnnualSubmission/DeleteHistoricNonFhlUkPropertyAnnualSubmissionConnector.scala
@@ -39,7 +39,7 @@ class DeleteHistoricNonFhlUkPropertyAnnualSubmissionConnector @Inject() (val htt
 
     import request._
 
-    val intent        = if (featureSwitches.isPassDeleteIntentEnabled) Some("DELETE") else None
+    val intent        = if (featureSwitches.isPassIntentEnabled) Some("DELETE") else None
     val downstreamUri = IfsUri[Unit](s"income-tax/nino/$nino/uk-properties/other/annual-summaries/${taxYear.asDownstream}")
 
     put(JsObject.empty, downstreamUri, intent)

--- a/app/v4/historicNonFhlUkPropertyPeriodSummary/list/ListHistoricNonFhlUkPropertyPeriodSummariesConnector.scala
+++ b/app/v4/historicNonFhlUkPropertyPeriodSummary/list/ListHistoricNonFhlUkPropertyPeriodSummariesConnector.scala
@@ -46,7 +46,7 @@ class ListHistoricNonFhlUkPropertyPeriodSummariesConnector @Inject() (val http: 
       case def1: Def1_ListHistoricNonFhlUkPropertyPeriodSummariesRequestData =>
         import def1._
 
-        val downstreamUri: IfsUri[Def1_ListHistoricNonFhlUkPropertyPeriodSummariesResponse] =
+        val downstreamUri =
           IfsUri[Def1_ListHistoricNonFhlUkPropertyPeriodSummariesResponse](s"income-tax/nino/$nino/uk-properties/other/periodic-summaries")
 
         val result = get(downstreamUri)

--- a/test/api/connectors/ConnectorSpec.scala
+++ b/test/api/connectors/ConnectorSpec.scala
@@ -16,14 +16,16 @@
 
 package api.connectors
 
-import config.MockAppConfig
-import mocks.{MockHttpClient}
+import com.google.common.base.Charsets
+import config.{BasicAuthDownstreamConfig, DownstreamConfig, MockAppConfig}
+import mocks.MockHttpClient
 import org.scalamock.handlers.CallHandler
 import play.api.http.{HeaderNames, MimeTypes, Status}
 import support.UnitSpec
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.UrlUtils
 
+import java.util.Base64
 import scala.concurrent.{ExecutionContext, Future}
 
 trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames {
@@ -31,12 +33,12 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
   lazy val baseUrl                   = "http://test-BaseUrl"
   implicit val correlationId: String = "a1e8057e-fbbc-47a8-a8b4-78d9f015c253"
 
-  val otherHeaders: Seq[(String, String)] = List(
+  val inputHeaders: Seq[(String, String)] = List(
     "Gov-Test-Scenario" -> "DEFAULT",
     "AnotherHeader"     -> "HeaderValue"
   )
 
-  implicit val hc: HeaderCarrier    = HeaderCarrier(otherHeaders = otherHeaders)
+  implicit val hc: HeaderCarrier    = HeaderCarrier(otherHeaders = inputHeaders)
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
 
   val dummyHeaderCarrierConfig: HeaderCarrier.Config =
@@ -46,65 +48,15 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
       Some("this-api")
     )
 
-  val requiredDesHeaders: Seq[(String, String)] = List(
-    "Authorization"     -> "Bearer des-token",
-    "Environment"       -> "des-environment",
-    "User-Agent"        -> "this-api",
-    "CorrelationId"     -> correlationId,
-    "Gov-Test-Scenario" -> "DEFAULT"
-  )
-
-  val allowedDesHeaders: Seq[String] = List(
-    "Accept",
-    "Gov-Test-Scenario",
-    "Content-Type",
-    "Location",
-    "X-Request-Timestamp",
-    "X-Session-Id"
-  )
-
-  val requiredIfsHeaders: Seq[(String, String)] = List(
-    "Authorization"     -> "Bearer ifs-token",
-    "Environment"       -> "ifs-environment",
-    "User-Agent"        -> "this-api",
-    "CorrelationId"     -> correlationId,
-    "Gov-Test-Scenario" -> "DEFAULT"
-  )
-
-  val allowedIfsHeaders: Seq[String] = List(
-    "Accept",
-    "Gov-Test-Scenario",
-    "Content-Type",
-    "Location",
-    "X-Request-Timestamp",
-    "X-Session-Id"
-  )
-
-  val requiredTysIfsHeaders: Seq[(String, String)] = List(
-    "Authorization"     -> "Bearer TYS-IFS-token",
-    "Environment"       -> "TYS-IFS-environment",
-    "User-Agent"        -> "this-api",
-    "CorrelationId"     -> correlationId,
-    "Gov-Test-Scenario" -> "DEFAULT"
-  )
-
-  val allowedTysIfsHeaders: Seq[String] = List(
-    "Accept",
-    "Gov-Test-Scenario",
-    "Content-Type",
-    "Location",
-    "X-Request-Timestamp",
-    "X-Session-Id"
-  )
-
   protected trait ConnectorTest extends MockHttpClient with MockAppConfig {
     protected val baseUrl: String = "http://test-BaseUrl"
 
-    implicit protected val hc: HeaderCarrier = HeaderCarrier(otherHeaders = otherHeaders)
-
-    protected val requiredHeaders: Seq[(String, String)]
-
+    protected def requiredHeaders: Seq[(String, String)]
     protected def excludedHeaders: Seq[(String, String)] = List("AnotherHeader" -> "HeaderValue")
+
+    protected val allowedHeaders: Seq[String] = List("Gov-Test-Scenario")
+
+    protected def intent: Option[String] = None
 
     protected def willGet[T](url: String, parameters: Seq[(String, String)] = Nil): CallHandler[Future[T]] = {
       MockHttpClient
@@ -153,34 +105,61 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
 
   }
 
-  protected trait DesTest extends ConnectorTest {
+  protected trait StandardConnectorTest extends ConnectorTest {
+    protected def name: String
 
-    protected lazy val requiredHeaders: Seq[(String, String)] = requiredDesHeaders
+    private val token       = s"$name-token"
+    private val environment = s"$name-environment"
 
-    MockedAppConfig.desBaseUrl returns this.baseUrl
-    MockedAppConfig.desToken returns "des-token"
-    MockedAppConfig.desEnvironment returns "des-environment"
-    MockedAppConfig.desEnvironmentHeaders returns Some(allowedDesHeaders)
+    protected def requiredHeaders: Seq[(String, String)] = List(
+      "Authorization"        -> s"Bearer $token",
+      "Environment"          -> environment,
+      "User-Agent"           -> "this-api",
+      "CorrelationId"        -> correlationId,
+      "Gov-Test-Scenario"    -> "DEFAULT"
+    ) ++ intent.map("intent" -> _)
+
+    protected final val config: DownstreamConfig = DownstreamConfig(this.baseUrl, environment, token, Some(allowedHeaders))
   }
 
-  protected trait IfsTest extends ConnectorTest {
+  protected trait DesTest extends StandardConnectorTest {
+    val name = "des"
 
-    protected lazy val requiredHeaders: Seq[(String, String)] = requiredIfsHeaders
-
-    MockedAppConfig.ifsBaseUrl returns this.baseUrl
-    MockedAppConfig.ifsToken returns "ifs-token"
-    MockedAppConfig.ifsEnvironment returns "ifs-environment"
-    MockedAppConfig.ifsEnvironmentHeaders returns Some(allowedIfsHeaders)
+    MockedAppConfig.desDownstreamConfig.anyNumberOfTimes() returns config
   }
 
-  protected trait TysIfsTest extends ConnectorTest {
+  protected trait IfsTest extends StandardConnectorTest {
+    override val name = "ifs"
 
-    protected lazy val requiredHeaders: Seq[(String, String)] = requiredTysIfsHeaders
+    MockedAppConfig.ifsDownstreamConfig.anyNumberOfTimes() returns config
+  }
 
-    MockedAppConfig.tysIfsBaseUrl returns this.baseUrl
-    MockedAppConfig.tysIfsToken returns "TYS-IFS-token"
-    MockedAppConfig.tysIfsEnvironment returns "TYS-IFS-environment"
-    MockedAppConfig.tysIfsEnvironmentHeaders returns Some(allowedIfsHeaders)
+  protected trait TysIfsTest extends StandardConnectorTest {
+    override val name = "tys-ifs"
+
+    MockedAppConfig.tysIfsDownstreamConfig.anyNumberOfTimes() returns config
+  }
+
+  protected trait HipTest extends ConnectorTest {
+    private val clientId     = "clientId"
+    private val clientSecret = "clientSecret"
+
+    private val token =
+      Base64.getEncoder.encodeToString(s"$clientId:$clientSecret".getBytes(Charsets.UTF_8))
+
+    private val environment = "hip-environment"
+
+    protected def requiredHeaders: Seq[(String, String)] = List(
+      "Authorization"        -> s"Basic $token",
+      "Environment"          -> environment,
+      "User-Agent"           -> "this-api",
+      "CorrelationId"        -> correlationId,
+      "Gov-Test-Scenario"    -> "DEFAULT"
+    ) ++ intent.map("intent" -> _)
+
+    MockedAppConfig.hipDownstreamConfig
+      .anyNumberOfTimes() returns BasicAuthDownstreamConfig(this.baseUrl, environment, clientId, clientSecret, Some(allowedHeaders))
+
   }
 
 }

--- a/test/api/connectors/DownstreamStrategySpec.scala
+++ b/test/api/connectors/DownstreamStrategySpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.connectors
+
+import config.{BasicAuthDownstreamConfig, DownstreamConfig, MockAppConfig}
+import org.scalatest.concurrent.ScalaFutures
+import support.UnitSpec
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class DownstreamStrategySpec extends UnitSpec with ScalaFutures with MockAppConfig {
+
+  "StandardStrategy" must {
+    "use the supplied DownstreamConfig" in {
+      val downstreamConfig =
+        DownstreamConfig(baseUrl = "someBaseUrl", env = "someEnv", token = "someToken", environmentHeaders = Some(Seq("header1", "header2")))
+
+      val strategy = DownstreamStrategy.standardStrategy(downstreamConfig)
+
+      strategy.baseUrl shouldBe "someBaseUrl"
+      strategy.contractHeaders("someCorrelationId").futureValue should contain theSameElementsAs
+        Seq(
+          "Authorization" -> "Bearer someToken",
+          "Environment"   -> "someEnv",
+          "CorrelationId" -> "someCorrelationId"
+        )
+      strategy.environmentHeaders should contain theSameElementsAs Seq("header1", "header2")
+    }
+  }
+
+  "BasicAuthStrategy" must {
+    "use the supplied BasicAuthDownstreamConfig and ClientAuthConfig" in {
+      val downstreamConfig =
+        BasicAuthDownstreamConfig(
+          baseUrl = "someBaseUrl",
+          env = "someEnv",
+          clientId = "someClient",
+          clientSecret = "someSecret",
+          environmentHeaders = Some(Seq("header1", "header2")))
+
+      val strategy = DownstreamStrategy.basicAuthStrategy(downstreamConfig)
+
+      strategy.baseUrl shouldBe "someBaseUrl"
+      strategy.contractHeaders("someCorrelationId").futureValue should contain theSameElementsAs
+        Seq(
+          "Authorization" -> "Basic c29tZUNsaWVudDpzb21lU2VjcmV0",
+          "Environment"   -> "someEnv",
+          "CorrelationId" -> "someCorrelationId"
+        )
+      strategy.environmentHeaders should contain theSameElementsAs Seq("header1", "header2")
+
+    }
+  }
+
+}

--- a/test/config/FeatureSwitchesSpec.scala
+++ b/test/config/FeatureSwitchesSpec.scala
@@ -26,13 +26,13 @@ class FeatureSwitchesSpec extends UnitSpec with ScalaCheckPropertyChecks {
     "return true" when {
       "the feature switch is set to true" in {
         val config = Configuration(
-          "passDeleteIntentHeader.enabled"  -> true,
+          "passIntentHeader.enabled"        -> true,
           "ruleSubmissionDateIssue.enabled" -> true
         )
 
         val featureSwitches = FeatureSwitches(config)
 
-        featureSwitches.isPassDeleteIntentEnabled shouldBe true
+        featureSwitches.isPassIntentEnabled shouldBe true
         featureSwitches.isRuleSubmissionDateErrorEnabled shouldBe true
       }
       "the feature switch is not present in the config" in {
@@ -40,21 +40,21 @@ class FeatureSwitchesSpec extends UnitSpec with ScalaCheckPropertyChecks {
 
         val featureSwitches = FeatureSwitches(config)
 
-        featureSwitches.isPassDeleteIntentEnabled shouldBe true
+        featureSwitches.isPassIntentEnabled shouldBe true
         featureSwitches.isRuleSubmissionDateErrorEnabled shouldBe true
       }
     }
     "return false" when {
       "the feature switch is set to false" in {
         val config = Configuration(
-          "passDeleteIntentHeader.enabled"  -> false,
+          "passIntentHeader.enabled"        -> false,
           "ruleSubmissionDateIssue.enabled" -> false,
           "allowNegativeExpenses.enabled"   -> false
         )
 
         val featureSwitches = FeatureSwitches(config)
 
-        featureSwitches.isPassDeleteIntentEnabled shouldBe false
+        featureSwitches.isPassIntentEnabled shouldBe false
         featureSwitches.isRuleSubmissionDateErrorEnabled shouldBe false
       }
     }

--- a/test/config/MockAppConfig.scala
+++ b/test/config/MockAppConfig.scala
@@ -28,27 +28,13 @@ trait MockAppConfig extends MockFactory {
   implicit val mockAppConfig: AppConfig = mock[AppConfig]
 
   object MockedAppConfig {
-    // MTD ID Lookup Config
+    def desDownstreamConfig: CallHandler0[DownstreamConfig]         = (() => mockAppConfig.desDownstreamConfig: DownstreamConfig).expects()
+    def ifsDownstreamConfig: CallHandler0[DownstreamConfig]         = (() => mockAppConfig.ifsDownstreamConfig: DownstreamConfig).expects()
+    def tysIfsDownstreamConfig: CallHandler0[DownstreamConfig]      = (() => mockAppConfig.tysIfsDownstreamConfig: DownstreamConfig).expects()
+    def hipDownstreamConfig: CallHandler[BasicAuthDownstreamConfig] = (() => mockAppConfig.hipDownstreamConfig: BasicAuthDownstreamConfig).expects()
+
+    // MTD IF Lookup Config
     def mtdIdBaseUrl: CallHandler[String] = (() => mockAppConfig.mtdIdBaseUrl).expects()
-
-    // DES Config
-    def desBaseUrl: CallHandler[String]                         = (() => mockAppConfig.desBaseUrl).expects()
-    def desToken: CallHandler[String]                           = (() => mockAppConfig.desToken).expects()
-    def desEnvironment: CallHandler[String]                     = (() => mockAppConfig.desEnv).expects()
-    def desEnvironmentHeaders: CallHandler[Option[Seq[String]]] = (() => mockAppConfig.desEnvironmentHeaders).expects()
-
-    // IFS Config
-    def ifsBaseUrl: CallHandler[String]                         = (() => mockAppConfig.ifsBaseUrl).expects()
-    def ifsToken: CallHandler[String]                           = (() => mockAppConfig.ifsToken).expects()
-    def ifsEnvironment: CallHandler[String]                     = (() => mockAppConfig.ifsEnv).expects()
-    def ifsEnvironmentHeaders: CallHandler[Option[Seq[String]]] = (() => mockAppConfig.ifsEnvironmentHeaders).expects()
-
-    // TYS IFS Config
-    def tysIfsBaseUrl: CallHandler[String]                         = (() => mockAppConfig.tysIfsBaseUrl).expects()
-    def tysIfsToken: CallHandler[String]                           = (() => mockAppConfig.tysIfsToken).expects()
-    def tysIfsEnv: CallHandler[String]                             = (() => mockAppConfig.tysIfsEnv).expects()
-    def tysIfsEnvironment: CallHandler[String]                     = (() => mockAppConfig.tysIfsEnv).expects()
-    def tysIfsEnvironmentHeaders: CallHandler[Option[Seq[String]]] = (() => mockAppConfig.tysIfsEnvironmentHeaders).expects()
 
     // API Config
     def featureSwitches: CallHandler[Configuration] = (() => mockAppConfig.featureSwitches).expects()

--- a/test/mocks/MockFeatureSwitches.scala
+++ b/test/mocks/MockFeatureSwitches.scala
@@ -24,7 +24,7 @@ trait MockFeatureSwitches extends MockFactory {
   implicit val mockFeatureSwitches: FeatureSwitches = mock[FeatureSwitches]
 
   object MockFeatureSwitches {
-    def isPassDeleteIntentEnabled: CallHandler[Boolean]        = (() => mockFeatureSwitches.isPassDeleteIntentEnabled).expects()
+    def isPassIntentEnabled: CallHandler[Boolean]              = (() => mockFeatureSwitches.isPassIntentEnabled).expects()
     def isRuleSubmissionDateErrorEnabled: CallHandler[Boolean] = (() => mockFeatureSwitches.isRuleSubmissionDateErrorEnabled).expects()
   }
 

--- a/test/v2/connectors/AmendForeignPropertyPeriodSummaryConnectorSpec.scala
+++ b/test/v2/connectors/AmendForeignPropertyPeriodSummaryConnectorSpec.scala
@@ -21,7 +21,6 @@ import api.models.domain.{BusinessId, Nino, SubmissionId, TaxYear}
 import api.models.errors.{DownstreamErrorCode, DownstreamErrors}
 import api.models.outcomes.ResponseWrapper
 import org.scalamock.handlers.CallHandler
-import uk.gov.hmrc.http.HeaderCarrier
 import v2.models.request.amendForeignPropertyPeriodSummary._
 
 import scala.concurrent.Future
@@ -45,19 +44,6 @@ class AmendForeignPropertyPeriodSummaryConnectorSpec extends ConnectorSpec {
 
         val result: DownstreamOutcome[Unit] = await(connector.amendForeignPropertyPeriodSummary(request))
         result shouldBe outcome
-      }
-    }
-
-    "the vendor request has a different content-type" must {
-      "send the downstream request with the correct application/json content-type" in new IfsTest with Test {
-        def taxYear: TaxYear = preTysTaxYear
-        stubHttpResponse(outcome)
-        val vendorHc: HeaderCarrier = hc.copy(otherHeaders = otherHeaders :+ ("Content-Type" -> "some-other-content-type"))
-
-        withClue("If the Content-Type isn't set correctly, the downstream mock will fail") {
-          val result: DownstreamOutcome[Unit] = await(connector.amendForeignPropertyPeriodSummary(request)(vendorHc, ec, correlationId))
-          result shouldBe outcome
-        }
       }
     }
 

--- a/test/v2/connectors/DeleteHistoricUkPropertyAnnualSubmissionConnectorSpec.scala
+++ b/test/v2/connectors/DeleteHistoricUkPropertyAnnualSubmissionConnectorSpec.scala
@@ -34,9 +34,9 @@ class DeleteHistoricUkPropertyAnnualSubmissionConnectorSpec extends ConnectorSpe
     "send a request and return no content" when {
       "using FHL data" in new IfsTest with Test {
         lazy val propertyType: HistoricPropertyType                    = HistoricPropertyType.Fhl
-        override lazy val requiredHeaders: scala.Seq[(String, String)] = requiredIfsHeaders :+ ("intent" -> "DELETE")
+        override lazy val requiredHeaders: scala.Seq[(String, String)] = super.requiredHeaders :+ ("intent" -> "DELETE")
 
-        MockFeatureSwitches.isPassDeleteIntentEnabled.returns(true)
+        MockFeatureSwitches.isPassIntentEnabled.returns(true)
 
         willPut(
           url = s"$baseUrl/income-tax/nino/$nino/uk-properties/furnished-holiday-lettings/annual-summaries/2022",
@@ -50,9 +50,9 @@ class DeleteHistoricUkPropertyAnnualSubmissionConnectorSpec extends ConnectorSpe
 
       "using non-FHL data" in new IfsTest with Test {
         lazy val propertyType: HistoricPropertyType                    = HistoricPropertyType.NonFhl
-        override lazy val requiredHeaders: scala.Seq[(String, String)] = requiredIfsHeaders :+ ("intent" -> "DELETE")
+        override lazy val requiredHeaders: scala.Seq[(String, String)] = super.requiredHeaders :+ ("intent" -> "DELETE")
 
-        MockFeatureSwitches.isPassDeleteIntentEnabled.returns(true)
+        MockFeatureSwitches.isPassIntentEnabled.returns(true)
 
         willPut(
           url = s"$baseUrl/income-tax/nino/$nino/uk-properties/other/annual-summaries/2022",
@@ -64,11 +64,11 @@ class DeleteHistoricUkPropertyAnnualSubmissionConnectorSpec extends ConnectorSpe
         result shouldBe expectedOutcome
       }
 
-      "isPassDeleteIntentHeader feature switch is off" in new IfsTest with Test {
+      "isPassIntentHeader feature switch is off" in new IfsTest with Test {
         override lazy val excludedHeaders: scala.Seq[(String, String)] = super.excludedHeaders :+ ("intent" -> "DELETE")
         lazy val propertyType: HistoricPropertyType                    = HistoricPropertyType.NonFhl
 
-        MockFeatureSwitches.isPassDeleteIntentEnabled returns false
+        MockFeatureSwitches.isPassIntentEnabled returns false
 
         willPut(url = s"$baseUrl/income-tax/nino/$nino/uk-properties/other/annual-summaries/2022", body = JsObject.empty)
           .returns(Future.successful(expectedOutcome))

--- a/test/v2/connectors/RetrieveHistoricFhlUkPropertyAnnualSubmissionConnectorSpec.scala
+++ b/test/v2/connectors/RetrieveHistoricFhlUkPropertyAnnualSubmissionConnectorSpec.scala
@@ -67,12 +67,9 @@ class RetrieveHistoricFhlUkPropertyAnnualSubmissionConnectorSpec extends Connect
 
     def stubHttpResponse(outcome: DownstreamOutcome[RetrieveHistoricFhlUkPropertyAnnualSubmissionResponse])
         : CallHandler[Future[DownstreamOutcome[RetrieveHistoricFhlUkPropertyAnnualSubmissionResponse]]]#Derived = {
-      MockHttpClient
-        .get(
-          url = s"$baseUrl/income-tax/nino/$nino/uk-properties/furnished-holiday-lettings/annual-summaries/$downstreamTaxYear",
-          config = dummyHeaderCarrierConfig,
-          requiredHeaders = requiredIfsHeaders
-        )
+      willGet(
+        url = s"$baseUrl/income-tax/nino/$nino/uk-properties/furnished-holiday-lettings/annual-summaries/$downstreamTaxYear"
+      )
         .returns(Future.successful(outcome))
     }
 

--- a/test/v4/amendForeignPropertyPeriodSummary/AmendForeignPropertyPeriodSummaryConnectorSpec.scala
+++ b/test/v4/amendForeignPropertyPeriodSummary/AmendForeignPropertyPeriodSummaryConnectorSpec.scala
@@ -21,7 +21,6 @@ import api.models.domain.{BusinessId, Nino, SubmissionId, TaxYear}
 import api.models.errors.{DownstreamErrorCode, DownstreamErrors}
 import api.models.outcomes.ResponseWrapper
 import org.scalamock.handlers.CallHandler
-import uk.gov.hmrc.http.HeaderCarrier
 import v4.amendForeignPropertyPeriodSummary.model.request.{
   AmendForeignPropertyPeriodSummaryRequestData,
   Def1_AmendForeignPropertyPeriodSummaryRequestBody,
@@ -49,19 +48,6 @@ class AmendForeignPropertyPeriodSummaryConnectorSpec extends ConnectorSpec {
 
         val result: DownstreamOutcome[Unit] = await(connector.amendForeignPropertyPeriodSummary(request))
         result shouldBe outcome
-      }
-    }
-
-    "the vendor request has a different content-type" must {
-      "send the downstream request with the correct application/json content-type" in new IfsTest with Test {
-        def taxYear: TaxYear = preTysTaxYear
-        stubHttpResponse(outcome)
-        val vendorHc: HeaderCarrier = hc.copy(otherHeaders = otherHeaders :+ ("Content-Type" -> "some-other-content-type"))
-
-        withClue("If the Content-Type isn't set correctly, the downstream mock will fail") {
-          val result: DownstreamOutcome[Unit] = await(connector.amendForeignPropertyPeriodSummary(request)(vendorHc, ec, correlationId))
-          result shouldBe outcome
-        }
       }
     }
 

--- a/test/v4/deleteHistoricFhlUkPropertyAnnualSubmission/DeleteHistoricFhlUkPropertyAnnualSubmissionConnectorSpec.scala
+++ b/test/v4/deleteHistoricFhlUkPropertyAnnualSubmission/DeleteHistoricFhlUkPropertyAnnualSubmissionConnectorSpec.scala
@@ -34,9 +34,9 @@ class DeleteHistoricFhlUkPropertyAnnualSubmissionConnectorSpec extends Connector
     "send a request and return no content" when {
       "using FHL data" in new IfsTest with Test {
         lazy val propertyType: HistoricPropertyType                    = HistoricPropertyType.Fhl
-        override lazy val requiredHeaders: scala.Seq[(String, String)] = requiredIfsHeaders :+ ("intent" -> "DELETE")
+        override lazy val requiredHeaders: scala.Seq[(String, String)] = super.requiredHeaders :+ ("intent" -> "DELETE")
 
-        MockFeatureSwitches.isPassDeleteIntentEnabled.returns(true)
+        MockFeatureSwitches.isPassIntentEnabled.returns(true)
 
         willPut(
           url = s"$baseUrl/income-tax/nino/$nino/uk-properties/furnished-holiday-lettings/annual-summaries/2022",
@@ -50,9 +50,9 @@ class DeleteHistoricFhlUkPropertyAnnualSubmissionConnectorSpec extends Connector
 
       "using non-FHL data" in new IfsTest with Test {
         lazy val propertyType: HistoricPropertyType                    = HistoricPropertyType.NonFhl
-        override lazy val requiredHeaders: scala.Seq[(String, String)] = requiredIfsHeaders :+ ("intent" -> "DELETE")
+        override lazy val requiredHeaders: scala.Seq[(String, String)] = super.requiredHeaders :+ ("intent" -> "DELETE")
 
-        MockFeatureSwitches.isPassDeleteIntentEnabled.returns(true)
+        MockFeatureSwitches.isPassIntentEnabled.returns(true)
 
         willPut(
           url = s"$baseUrl/income-tax/nino/$nino/uk-properties/other/annual-summaries/2022",
@@ -64,11 +64,11 @@ class DeleteHistoricFhlUkPropertyAnnualSubmissionConnectorSpec extends Connector
         result shouldBe expectedOutcome
       }
 
-      "isPassDeleteIntentHeader feature switch is off" in new IfsTest with Test {
+      "isPassIntentHeader feature switch is off" in new IfsTest with Test {
         override lazy val excludedHeaders: scala.Seq[(String, String)] = super.excludedHeaders :+ ("intent" -> "DELETE")
         lazy val propertyType: HistoricPropertyType                    = HistoricPropertyType.NonFhl
 
-        MockFeatureSwitches.isPassDeleteIntentEnabled returns false
+        MockFeatureSwitches.isPassIntentEnabled returns false
 
         willPut(url = s"$baseUrl/income-tax/nino/$nino/uk-properties/other/annual-summaries/2022", body = JsObject.empty)
           .returns(Future.successful(expectedOutcome))

--- a/test/v4/deleteHistoricNonFhlUkPropertyAnnualSubmission/DeleteHistoricNonFhlUkPropertyAnnualSubmissionConnectorSpec.scala
+++ b/test/v4/deleteHistoricNonFhlUkPropertyAnnualSubmission/DeleteHistoricNonFhlUkPropertyAnnualSubmissionConnectorSpec.scala
@@ -37,9 +37,9 @@ class DeleteHistoricNonFhlUkPropertyAnnualSubmissionConnectorSpec extends Connec
     "send a request and return no content" when {
 
       "sending a non-FHL request" in new IfsTest with Test {
-        override lazy val requiredHeaders: scala.Seq[(String, String)] = requiredIfsHeaders :+ ("intent" -> "DELETE")
+        override lazy val requiredHeaders: scala.Seq[(String, String)] = super.requiredHeaders :+ ("intent" -> "DELETE")
 
-        MockFeatureSwitches.isPassDeleteIntentEnabled.returns(true)
+        MockFeatureSwitches.isPassIntentEnabled.returns(true)
 
         willPut(
           url = s"$baseUrl/income-tax/nino/$nino/uk-properties/other/annual-summaries/2022",
@@ -51,10 +51,10 @@ class DeleteHistoricNonFhlUkPropertyAnnualSubmissionConnectorSpec extends Connec
         result shouldBe expectedOutcome
       }
 
-      "isPassDeleteIntentHeader feature switch is off" in new IfsTest with Test {
+      "isPassIntentHeader feature switch is off" in new IfsTest with Test {
         override lazy val excludedHeaders: scala.Seq[(String, String)] = super.excludedHeaders :+ ("intent" -> "DELETE")
 
-        MockFeatureSwitches.isPassDeleteIntentEnabled returns false
+        MockFeatureSwitches.isPassIntentEnabled returns false
 
         willPut(url = s"$baseUrl/income-tax/nino/$nino/uk-properties/other/annual-summaries/2022", body = JsObject.empty)
           .returns(Future.successful(expectedOutcome))

--- a/test/v4/retrieveHistoricFhlUkPropertyAnnualSubmission/RetrieveHistoricFhlUkPropertyAnnualSubmissionConnectorSpec.scala
+++ b/test/v4/retrieveHistoricFhlUkPropertyAnnualSubmission/RetrieveHistoricFhlUkPropertyAnnualSubmissionConnectorSpec.scala
@@ -67,12 +67,9 @@ class RetrieveHistoricFhlUkPropertyAnnualSubmissionConnectorSpec extends Connect
 
     def stubHttpResponse(outcome: DownstreamOutcome[RetrieveHistoricFhlUkPropertyAnnualSubmissionResponse])
         : CallHandler[Future[DownstreamOutcome[RetrieveHistoricFhlUkPropertyAnnualSubmissionResponse]]]#Derived = {
-      MockHttpClient
-        .get(
-          url = s"$baseUrl/income-tax/nino/$nino/uk-properties/furnished-holiday-lettings/annual-summaries/$downstreamTaxYear",
-          config = dummyHeaderCarrierConfig,
-          requiredHeaders = requiredIfsHeaders
-        )
+      willGet(
+        url = s"$baseUrl/income-tax/nino/$nino/uk-properties/furnished-holiday-lettings/annual-summaries/$downstreamTaxYear"
+      )
         .returns(Future.successful(outcome))
     }
 


### PR DESCRIPTION
* Required for new CS endpoints
* Base on latest connector classes (that support HIP)
* Rename passDeleteIntentHeader to a more general passIntentHeader feature switch