### PR TITLE
[MTDSA-35966]: Delete Property Annual Submission to HIP migration

### DIFF
--- a/app/v6/deletePropertyAnnualSubmission/DeletePropertyAnnualSubmissionConnector.scala
+++ b/app/v6/deletePropertyAnnualSubmission/DeletePropertyAnnualSubmissionConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package v6.deletePropertyAnnualSubmission
 
-import api.config.AppConfig
-import api.connectors.DownstreamUri.IfsUri
+import api.config.{AppConfig, ConfigFeatureSwitches}
+import api.connectors.DownstreamUri.{HipUri, IfsUri}
 import api.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
-import api.connectors.{BaseDownstreamConnector, DownstreamOutcome}
+import api.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
-import v6.deletePropertyAnnualSubmission.model.request.{Def1_DeletePropertyAnnualSubmissionRequestData, DeletePropertyAnnualSubmissionRequestData}
+import v6.deletePropertyAnnualSubmission.model.request.DeletePropertyAnnualSubmissionRequestData
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -35,28 +35,22 @@ class DeletePropertyAnnualSubmissionConnector @Inject() (val http: HttpClientV2,
       ec: ExecutionContext,
       correlationId: String): Future[DownstreamOutcome[Unit]] = {
 
-    request match {
-      case def1: Def1_DeletePropertyAnnualSubmissionRequestData =>
-        import def1.*
-        val (downstreamUri, queryParams) =
-          if (taxYear.useTaxYearSpecificApi) {
-            (
-              IfsUri[Unit](s"income-tax/business/property/annual/${taxYear.asTysDownstream}/$nino/$businessId"),
-              Nil
-            )
-          } else {
-            (
-              IfsUri[Unit](s"income-tax/business/property/annual"),
-              List(
-                "taxableEntityId" -> nino.nino,
-                "incomeSourceId"  -> businessId.businessId,
-                "taxYear"         -> taxYear.asMtd // Note that MTD tax year format is used
-              )
-            )
-          }
-        delete(downstreamUri, queryParams)
+    import request.*
+
+    val queryParams = List(
+      "taxableEntityId" -> nino.nino,
+      "incomeSourceId"  -> businessId.businessId,
+      "taxYear"         -> taxYear.asMtd
+    )
+
+    lazy val downstreamUri1596 = IfsUri[Unit](s"income-tax/business/property/annual")
+    lazy val downstreamUri1863 = if (taxYear.year >= 2026 && ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1863")) {
+      HipUri[Unit](s"itsa/income-tax/v1/${taxYear.asTysDownstream}/business/property/annual/$nino/$businessId")
+    } else {
+      IfsUri[Unit](s"income-tax/business/property/annual/${taxYear.asTysDownstream}/$nino/$businessId")
     }
 
+    if (taxYear.useTaxYearSpecificApi) delete(downstreamUri1863) else delete(downstreamUri1596, queryParams)
   }
 
 }

--- a/app/v6/deletePropertyAnnualSubmission/DeletePropertyAnnualSubmissionService.scala
+++ b/app/v6/deletePropertyAnnualSubmission/DeletePropertyAnnualSubmissionService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,10 +49,11 @@ class DeletePropertyAnnualSubmissionService @Inject() (connector: DeleteProperty
     )
 
     val extraTysErrors = Map(
-      "INVALID_INCOMESOURCE_ID" -> BusinessIdFormatError,
-      "INVALID_CORRELATION_ID"  -> InternalError,
-      "NOT_FOUND"               -> NotFoundError,
-      "TAX_YEAR_NOT_SUPPORTED"  -> RuleTaxYearNotSupportedError
+      "INVALID_INCOMESOURCE_ID"  -> BusinessIdFormatError,
+      "INVALID_INCOME_SOURCE_ID" -> BusinessIdFormatError,
+      "INVALID_CORRELATION_ID"   -> InternalError,
+      "NOT_FOUND"                -> NotFoundError,
+      "TAX_YEAR_NOT_SUPPORTED"   -> RuleTaxYearNotSupportedError
     )
 
     downstreamErrors ++ extraTysErrors

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -165,6 +165,8 @@ feature-switch {
     enabled = true
     released-in-production = false
   }
+  
+  ifs_hip_migration_1863.enabled = true
 
 }
 

--- a/it/test/v6/deletePropertyAnnualSubmission/def1/Def1_DeletePropertyAnnualSubmissionHipIspec.scala
+++ b/it/test/v6/deletePropertyAnnualSubmission/def1/Def1_DeletePropertyAnnualSubmissionHipIspec.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v6.deletePropertyAnnualSubmission.def1
+
+import api.models.errors.*
+import api.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
+import api.support.IntegrationBaseSpec
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import common.models.errors.RuleOutsideAmendmentWindowError
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.*
+
+class Def1_DeletePropertyAnnualSubmissionHipIspec extends IntegrationBaseSpec {
+
+  "calling the delete property annual submission endpoint" should {
+    "return a 204 status code" when {
+      "any valid request is made for a Tax Year Specific (TYS) tax year" in new Test {
+        override def setupStubs(): StubMapping = DownstreamStub.onSuccess(
+          method = DownstreamStub.DELETE,
+          uri = downstreamUri,
+          status = NO_CONTENT
+        )
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+    }
+
+    "return error according to spec" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestBusinessId: String,
+                                requestTaxYear: String,
+                                expectedStatus: Int,
+                                expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new Test {
+
+            override val nino: String       = requestNino
+            override val businessId: String = requestBusinessId
+            override val taxYear: String    = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "XAIS12345678910", "2025-26", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "invalid-business-id", "2025-26", BAD_REQUEST, BusinessIdFormatError),
+          ("AA123456A", "XAIS12345678910", "20256", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "XAIS12345678910", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "XAIS12345678910", "2025-27", BAD_REQUEST, RuleTaxYearRangeInvalidError)
+        )
+        input.foreach(args => validationErrorTest.tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns a code $downstreamCode error and status $downstreamStatus" in new Test {
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              MtdIdLookupStub.ninoFound(nino)
+              AuthStub.authorised()
+              DownstreamStub.onError(DownstreamStub.DELETE, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.json shouldBe Json.toJson(expectedBody)
+            response.status shouldBe expectedStatus
+            response.header("X-CorrelationId").nonEmpty shouldBe true
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val errors = List(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_INCOME_SOURCE_ID", BAD_REQUEST, BusinessIdFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "UNMATCHED_STUB_ERROR", BAD_REQUEST, RuleIncorrectGovTestScenarioError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindowError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        errors.foreach(serviceErrorTest.tupled)
+      }
+    }
+
+  }
+
+  private trait Test {
+    val nino: String       = "AA123456A"
+    val businessId: String = "XAIS12345678910"
+    val taxYear: String = "2025-26"
+    val downstreamUri: String = s"/itsa/income-tax/v1/25-26/business/property/annual/$nino/$businessId"
+
+    def setupStubs(): StubMapping
+
+    def request(): WSRequest = {
+      AuthStub.authorised()
+      MtdIdLookupStub.ninoFound(nino)
+      setupStubs()
+      buildRequest(s"/$nino/$businessId/annual/$taxYear")
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.6.0+json"),
+          (AUTHORIZATION, "Bearer 123")
+        )
+    }
+
+    def errorBody(`type`: String): String =
+      s"""
+         |{
+         |  "origin": "HoD",
+         |  "response": {
+         |    "failures": [
+         |      {
+         |        "type": "${`type`}",
+         |        "reason": "message"
+         |      }
+         |    ]
+         |  }
+         |}
+      """.stripMargin
+  }
+
+}

--- a/it/test/v6/deletePropertyAnnualSubmission/def1/Def1_DeletePropertyAnnualSubmissionIfsIspec.scala
+++ b/it/test/v6/deletePropertyAnnualSubmission/def1/Def1_DeletePropertyAnnualSubmissionIfsIspec.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v6.deletePropertyAnnualSubmission.def1
+
+import api.models.errors.*
+import api.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
+import api.support.IntegrationBaseSpec
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import common.models.errors.RuleOutsideAmendmentWindowError
+import play.api.libs.json.{JsObject, Json}
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.*
+
+class Def1_DeletePropertyAnnualSubmissionIfsIspec extends IntegrationBaseSpec {
+  override def servicesConfig: Map[String, Any] = Map("feature-switch.ifs_hip_migration_1863.enabled" -> false) ++ super.servicesConfig
+
+  "calling the delete property annual submission endpoint" should {
+    "return a 204 status code" when {
+      "any valid request is made for a Tax Year Specific (TYS) tax year" in new TysTest {
+        override def setupStubs(): StubMapping = DownstreamStub.onSuccess(
+          method = DownstreamStub.DELETE,
+          uri = downstreamUri,
+          status = NO_CONTENT
+        )
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+
+      "any valid request is made" in new NonTysTest {
+        override def setupStubs(): StubMapping = DownstreamStub.onSuccess(
+          method = DownstreamStub.DELETE,
+          queryParams = downstreamQueryParams,
+          uri = downstreamUri,
+          status = NO_CONTENT,
+          body = JsObject.empty
+        )
+
+        val response: WSResponse = await(request().delete())
+        response.status shouldBe NO_CONTENT
+        response.header("X-CorrelationId").nonEmpty shouldBe true
+      }
+    }
+
+    "return error according to spec" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestBusinessId: String,
+                                requestTaxYear: String,
+                                expectedStatus: Int,
+                                expectedBody: MtdError): Unit = {
+          s"Non-Tys validation fails with ${expectedBody.code} error" in new NonTysTest with Test {
+
+            override val nino: String       = requestNino
+            override val businessId: String = requestBusinessId
+            override val taxYear: String    = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+
+          s"validation fails with ${expectedBody.code} error" in new TysTest with Test {
+
+            override val nino: String       = requestNino
+            override val businessId: String = requestBusinessId
+            override val taxYear: String    = requestTaxYear
+
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val input = Seq(
+          ("AA1123A", "XAIS12345678910", "2025-26", BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "invalid-business-id", "2025-26", BAD_REQUEST, BusinessIdFormatError),
+          ("AA123456A", "XAIS12345678910", "20256", BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "XAIS12345678910", "2018-19", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          ("AA123456A", "XAIS12345678910", "2025-27", BAD_REQUEST, RuleTaxYearRangeInvalidError)
+        )
+        input.foreach(args => validationErrorTest.tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns a code $downstreamCode error and status $downstreamStatus" in new TysTest with Test {
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              MtdIdLookupStub.ninoFound(nino)
+              AuthStub.authorised()
+              DownstreamStub.onError(DownstreamStub.DELETE, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request().delete())
+            response.json shouldBe Json.toJson(expectedBody)
+            response.status shouldBe expectedStatus
+            response.header("X-CorrelationId").nonEmpty shouldBe true
+            response.header("Content-Type") shouldBe Some("application/json")
+          }
+        }
+
+        val errors = List(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_INCOMESOURCE_ID", BAD_REQUEST, BusinessIdFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "UNMATCHED_STUB_ERROR", BAD_REQUEST, RuleIncorrectGovTestScenarioError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindowError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        errors.foreach(serviceErrorTest.tupled)
+      }
+    }
+
+  }
+
+  private trait Test {
+    val nino: String       = "AA123456A"
+    val businessId: String = "XAIS12345678910"
+
+    def taxYear: String
+    def downstreamUri: String
+
+    def setupStubs(): StubMapping
+
+    def request(): WSRequest = {
+      AuthStub.authorised()
+      MtdIdLookupStub.ninoFound(nino)
+      setupStubs()
+      buildRequest(s"/$nino/$businessId/annual/$taxYear")
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.6.0+json"),
+          (AUTHORIZATION, "Bearer 123")
+        )
+    }
+
+    def errorBody(code: String): String = {
+      s"""
+         |{
+         |  "failures": [
+         |    {
+         |      "code": "${code}",
+         |      "reason": "message"
+         |    }
+         |  ]
+         |}
+      """.stripMargin
+    }
+
+  }
+
+  private trait TysTest extends Test {
+    def taxYear: String       = "2025-26"
+    def downstreamUri: String = s"/income-tax/business/property/annual/25-26/$nino/$businessId"
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: String       = "2022-23"
+    def downstreamUri: String = s"/income-tax/business/property/annual"
+
+    def downstreamQueryParams: Map[String, String] = Map(
+      "taxableEntityId" -> nino,
+      "incomeSourceId"  -> businessId,
+      "taxYear"         -> "2022-23"
+    )
+
+  }
+
+}

--- a/test/v6/deletePropertyAnnualSubmission/DeletePropertyAnnualSubmissionConnectorSpec.scala
+++ b/test/v6/deletePropertyAnnualSubmission/DeletePropertyAnnualSubmissionConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import api.connectors.{ConnectorSpec, DownstreamOutcome}
 import api.models.domain.{BusinessId, Nino, TaxYear}
 import api.models.errors.{DownstreamErrorCode, DownstreamErrors}
 import api.models.outcomes.ResponseWrapper
+import play.api.Configuration
 import uk.gov.hmrc.http.StringContextOps
 import v6.deletePropertyAnnualSubmission.model.request.{Def1_DeletePropertyAnnualSubmissionRequestData, DeletePropertyAnnualSubmissionRequestData}
 
@@ -30,46 +31,88 @@ class DeletePropertyAnnualSubmissionConnectorSpec extends ConnectorSpec {
   private val nino       = Nino("AA123456A")
   private val businessId = BusinessId("XAIS12345678910")
 
-  private val preTysTaxYear = TaxYear.fromMtd("2021-22")
-  private val tysTaxYear    = TaxYear.fromMtd("2023-24")
+  private val preTysTaxYear  = TaxYear.fromMtd("2021-22")
+  private val tysTaxYear2324 = TaxYear.fromMtd("2023-24")
+  private val tysTaxYear2526 = TaxYear.fromMtd("2025-26")
 
-  "connector" when {
-    "the downstream response is a success" must {
+  "DeletePropertyAnnualSubmissionConnector" must {
+    "return a NO_CONTENT response" when {
       val outcome = Right(ResponseWrapper(correlationId, ()))
 
-      "return no content" in new IfsTest with Test {
+      "a nonTys deletion is made" in new IfsTest with Test {
         def taxYear: TaxYear = preTysTaxYear
         stubHttpResponse(outcome)
+
+        val result: DownstreamOutcome[Unit] = await(connector.deletePropertyAnnualSubmission(request))
+
+        result shouldBe outcome
+      }
+
+      "a TYS 2023-24 tax year deletion is made" in new IfsTest with Test {
+        def taxYear: TaxYear = tysTaxYear2324
+
+        stubIfsTysHttpResponse(outcome)
 
         val result: DownstreamOutcome[Unit] = await(connector.deletePropertyAnnualSubmission(request))
         result shouldBe outcome
       }
 
-      "return no content given a TYS tax year request" in new IfsTest with Test {
-        def taxYear: TaxYear = tysTaxYear
-        stubTysHttpResponse(outcome)
+      "a TYS 2025-26 tax year deletion is made and hip migration feature switch is disabled" in new IfsTest with Test {
+        def taxYear: TaxYear = tysTaxYear2526
+        MockedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1863.enabled" -> false))
+        stubIfsTysHttpResponse(outcome)
+
+        val result: DownstreamOutcome[Unit] = await(connector.deletePropertyAnnualSubmission(request))
+        result shouldBe outcome
+      }
+
+      "a TYS 2025-26 tax year deletion is made and hip migration feature switch is enabled" in new HipTest with Test {
+        def taxYear: TaxYear = tysTaxYear2526
+
+        MockedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1863.enabled" -> true))
+        stubHipTysHttpResponse(outcome)
 
         val result: DownstreamOutcome[Unit] = await(connector.deletePropertyAnnualSubmission(request))
         result shouldBe outcome
       }
     }
 
-    "the downstream response is an error" must {
+    "return the downstream error response" when {
       val downstreamErrorResponse: DownstreamErrors =
         DownstreamErrors.single(DownstreamErrorCode("SOME_ERROR"))
       val outcome = Left(ResponseWrapper(correlationId, downstreamErrorResponse))
 
-      "return the error" in new IfsTest with Test {
+      "a nonTys deletion is made" in new IfsTest with Test {
         def taxYear: TaxYear = preTysTaxYear
+        MockedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1863.enabled" -> false))
         stubHttpResponse(outcome)
 
         val result: DownstreamOutcome[Unit] = await(connector.deletePropertyAnnualSubmission(request))
         result shouldBe outcome
       }
 
-      "return the error given a TYS tax year request" in new IfsTest with Test {
-        def taxYear: TaxYear = tysTaxYear
-        stubTysHttpResponse(outcome)
+      "a TYS 2023-24 tax year deletion is made" in new IfsTest with Test {
+        def taxYear: TaxYear = tysTaxYear2324
+
+        stubIfsTysHttpResponse(outcome)
+
+        val result: DownstreamOutcome[Unit] = await(connector.deletePropertyAnnualSubmission(request))
+        result shouldBe outcome
+      }
+
+      "a TYS 2025-26 tax year deletion is made and hip migration feature switch is disabled" in new IfsTest with Test {
+        def taxYear: TaxYear = tysTaxYear2526
+        MockedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1863.enabled" -> false))
+        stubIfsTysHttpResponse(outcome)
+
+        val result: DownstreamOutcome[Unit] = await(connector.deletePropertyAnnualSubmission(request))
+        result shouldBe outcome
+      }
+
+      "a TYS 2025-26 tax year deletion is made and hip migration feature switch is enabled" in new HipTest with Test {
+        def taxYear: TaxYear = tysTaxYear2526
+        MockedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1863.enabled" -> true))
+        stubHipTysHttpResponse(outcome)
 
         val result: DownstreamOutcome[Unit] = await(connector.deletePropertyAnnualSubmission(request))
         result shouldBe outcome
@@ -95,9 +138,14 @@ class DeletePropertyAnnualSubmissionConnectorSpec extends ConnectorSpec {
         url = url"$baseUrl/income-tax/business/property/annual?taxableEntityId=AA123456A&incomeSourceId=XAIS12345678910&taxYear=2021-22"
       ).returns(Future.successful(outcome))
 
-    protected def stubTysHttpResponse(outcome: DownstreamOutcome[Unit]): Unit =
+    protected def stubIfsTysHttpResponse(outcome: DownstreamOutcome[Unit]): Unit =
       willDelete(
         url = url"$baseUrl/income-tax/business/property/annual/${request.taxYear.asTysDownstream}/${request.nino}/${request.businessId}"
+      ).returns(Future.successful(outcome))
+
+    protected def stubHipTysHttpResponse(outcome: DownstreamOutcome[Unit]): Unit =
+      willDelete(
+        url = url"$baseUrl/itsa/income-tax/v1/${request.taxYear.asTysDownstream}/business/property/annual/${request.nino}/${request.businessId}"
       ).returns(Future.successful(outcome))
 
   }

--- a/test/v6/deletePropertyAnnualSubmission/DeletePropertyAnnualSubmissionServiceSpec.scala
+++ b/test/v6/deletePropertyAnnualSubmission/DeletePropertyAnnualSubmissionServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ class DeletePropertyAnnualSubmissionServiceSpec extends ServiceSpec {
 
         val extraTysErrors = List(
           "INVALID_INCOMESOURCE_ID"  -> BusinessIdFormatError,
+          "INVALID_INCOME_SOURCE_ID" -> BusinessIdFormatError,
           "INVALID_CORRELATION_ID"   -> InternalError,
           "NOT_FOUND"                -> NotFoundError,
           "TAX_YEAR_NOT_SUPPORTED"   -> RuleTaxYearNotSupportedError,


### PR DESCRIPTION
### Pre TYS (22-23)
<img width="1496" height="576" alt="pre-TYS" src="https://github.com/user-attachments/assets/73d9ab59-dfa6-4e08-a261-c287e05e9352" />

### TYS (23-24)
<img width="1485" height="568" alt="TYS" src="https://github.com/user-attachments/assets/10a55447-ea49-483b-8ed9-36a334e0a9e8" />

### TYS (24-25)
<img width="1483" height="484" alt="TYS - HIP" src="https://github.com/user-attachments/assets/72113ef1-5ddf-455f-8fb3-5517c6066467" />

### TYS (25-26) 👈🏾 should call HIP when enabled
<img width="1473" height="596" alt="Screenshot 2026-08-07 at 11 00 18" src="https://github.com/user-attachments/assets/c72c9a48-32ae-40d8-b08d-07876c345bd9" />


---

### When HIP is Enabled
<img width="3391" height="625" alt="Screenshot 2026-08-07 at 10 49 13" src="https://github.com/user-attachments/assets/21277dd0-6c1d-49dc-af43-22e00b4ca8ca" />


### When HIP is Disabled
<img width="3371" height="612" alt="Screenshot 2026-08-07 at 10 50 48" src="https://github.com/user-attachments/assets/828ede2c-af66-4367-b6a7-3b8aec52d1a1" />


